### PR TITLE
Fix authentication issue with some keys

### DIFF
--- a/lib/services/blob/hmacsha256sign.js
+++ b/lib/services/blob/hmacsha256sign.js
@@ -17,7 +17,6 @@
 var crypto = require('crypto');
 
 var azureutil = require('../../util/util');
-var Base64 = require('../../util/base64');
 var HeaderConstants = require('../../util/constants').HeaderConstants;
 
 // Expose 'HmacSHA256Sign'.
@@ -30,12 +29,12 @@ exports = module.exports = HmacSha256Sign;
 */
 function HmacSha256Sign(accessKey) {
   this._accessKey = accessKey;
-  this._decodedAccessKey = Base64.decode64(this._accessKey);
+  this._decodedAccessKey = new Buffer(this._accessKey, 'base64');
 }
 
 /**
 * Computes a signature for the specified string using the HMAC-SHA256 algorithm.
-* 
+*
 * @param {string} stringToSign The UTF-8-encoded string to sign.
 * @return A String that contains the HMAC-SHA256-encoded signature.
 */


### PR DESCRIPTION
Fixes issue #36, as reported by @pofallon.

The original source would decode the base64 key to a string, which will work fine for most keys, but will fail for invalid utf8 sequences (and javascript / v8 has its share of those). Since node's crypto apis accept both strings and buffers as keys, the updated source will decode the key to a buffer instead, preserving all byte sequences, and pass that through to the the crypto api.
