### PR TITLE
Return metadata in blobResult when calling getBlobToStream

### DIFF
--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -1336,11 +1336,13 @@ BlobService.prototype.getBlobToStream = function (container, blob, writeStream, 
 
   this._setHeadersFromBlob(webResource, options);
 
+  var self = this;
   var processResponseCallback = function (responseObject, next) {
     responseObject.blobResult = null;
 
     if (!responseObject.error) {
       responseObject.blobResult = new BlobResult(container, blob);
+      responseObject.blobResult.metadata = self.parseMetadataHeaders(responseObject.response.headers);
       responseObject.blobResult.getPropertiesFromHeaders(responseObject.response.headers);
 
       var validateMD5 = !(options && options.disableContentMD5) && responseObject.blobResult.contentMD5;


### PR DESCRIPTION
Currently blobResult only contains properties (not metadata) when calling getBlobToStream.  I added a call to self.parseMetadataHeaders so that it will return both properties and metadata (similar to several other methods in the BlobService object).

Thanks!
