### PR TITLE
Process request 'error' events.

### DIFF
--- a/lib/services/core/serviceclient.js
+++ b/lib/services/core/serviceclient.js
@@ -239,6 +239,13 @@ ServiceClient.prototype._performRequest = function (webResource, body, options, 
         request = http.request(finalRequestOptions, processResponse);
       }
 
+      request.on('error', function(error) {
+        if (operationCallback) {
+          var responseObject = { error: error, response: null };
+          operationCallback(responseObject, next);
+        }
+      });
+
       // Pipe request body
       if (body && body.outputData) {
         request.end(body.outputData);


### PR DESCRIPTION
Currently there are no 'error' listeners on the request object, which causes node to throw when there are 'error' events fired.  'error' events on request object are usually fired if the underlying TCP connection gets killed.
