### PR TITLE
Ensure that proxy env variable settings work on unix

### DIFF
--- a/lib/services/core/serviceclient.js
+++ b/lib/services/core/serviceclient.js
@@ -45,7 +45,6 @@ ServiceClient.EnvironmentVariables = {
   AZURE_WRAP_NAMESPACE: 'AZURE_WRAP_NAMESPACE',
   HTTP_PROXY: 'HTTP_PROXY',
   HTTPS_PROXY: 'HTTPS_PROXY',
-  ALL_PROXY: 'ALL_PROXY',
   EMULATED: 'EMULATED'
 };
 
@@ -366,7 +365,7 @@ ServiceClient.prototype.withFilter = function (newFilter) {
 /*
 * Returns the host name to be used on the outgoing request.
 * This takes into consideration any proxy settings defined on the object or through
-* the environment variables ALL_PROXY, HTTPS_PROXY or HTTP_PROXY.
+* the environment variables HTTPS_PROXY or HTTP_PROXY.
 *
 * @return {string} The host name to be used.
 */
@@ -383,7 +382,7 @@ ServiceClient.prototype.getRequestHost = function () {
 /*
 * Returns the port number to be used on the outgoing request.
 * This takes into consideration any proxy settings defined on the object or through
-* the environment variables ALL_PROXY, HTTPS_PROXY or HTTP_PROXY.
+* the environment variables HTTPS_PROXY or HTTP_PROXY.
 *
 * @return {int} The port number to be used.
 */
@@ -419,19 +418,21 @@ ServiceClient.prototype._parseHost = function (host) {
 
 /*
 * Loads the fields "useProxy" and respective protocol, port and url
-* from the environment values ALL_PROXY, HTTPS_PROXY and HTTP_PROXY
+* from the environment values HTTPS_PROXY and HTTP_PROXY
 * in case those are set.
 *
 * @return {undefined}
 */
 ServiceClient.prototype._loadEnvironmentProxy = function() {
   var proxyUrl = null;
-  if (process.env[ServiceClient.EnvironmentVariables.ALL_PROXY]) {
-    proxyUrl = process.env[ServiceClient.EnvironmentVariables.ALL_PROXY];
-  } else if (process.env[ServiceClient.EnvironmentVariables.HTTPS_PROXY]) {
+  if (process.env[ServiceClient.EnvironmentVariables.HTTPS_PROXY]) {
     proxyUrl = process.env[ServiceClient.EnvironmentVariables.HTTPS_PROXY];
+  } else if (process.env[ServiceClient.EnvironmentVariables.HTTPS_PROXY.toLowerCase()]) {
+    proxyUrl = process.env[ServiceClient.EnvironmentVariables.HTTPS_PROXY.toLowerCase()];
   } else if (process.env[ServiceClient.EnvironmentVariables.HTTP_PROXY]) {
     proxyUrl = process.env[ServiceClient.EnvironmentVariables.HTTP_PROXY];
+  } else if (process.env[ServiceClient.EnvironmentVariables.HTTP_PROXY.toLowerCase()]) {
+    proxyUrl = process.env[ServiceClient.EnvironmentVariables.HTTP_PROXY.toLowerCase()];
   }
 
   if (proxyUrl) {


### PR DESCRIPTION
- all_proxy env. variable shouldn't be used at all because it points to SOCKS proxy (not HTTP proxy), which isn't used by the SDK.
- need to check for both lower-case and upper-case env variables
