### PR TITLE
bugfix: tableservice.commitBatch() did not work with entity contains non-ascii charactors

### DIFF
--- a/lib/services/table/batchserviceclient.js
+++ b/lib/services/table/batchserviceclient.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Copyright 2011 Microsoft Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,10 +100,9 @@ BatchServiceClient.prototype.addOperation = function (webResource, outputData) {
     webResource.headers[HeaderConstants.CONTENT_ID] = this.operations.length + 1;
 
     if (webResource.httpVerb !== ServiceClient.HTTP_VERB_DELETE) {
-      webResource.headers[HeaderConstants.CONTENT_TYPE] = 'application/atom+xml;type=entry';
+      webResource.headers[HeaderConstants.CONTENT_TYPE] = 'application/atom+xml;charset="utf-8";type=entry';
     }
-
-    webResource.headers[HeaderConstants.CONTENT_LENGTH] = outputData.length;
+    webResource.headers[HeaderConstants.CONTENT_LENGTH] = Buffer.byteLength(outputData, 'utf8'); //outputData.length;
   }
 
   this._setRequestUrl(webResource);
@@ -149,7 +148,7 @@ BatchServiceClient.prototype.commitBatch = function (optionsOrCallback, callback
   var changesetBoundary = 'changeset_' + crypto.createHash('md5').update("" + (new Date()).getTime()).digest("hex");
 
   var body = '--' + batchBoundary + '\n';
-  body += HeaderConstants.CONTENT_TYPE + ': multipart/mixed; boundary=' + changesetBoundary + '\n\n';
+  body += HeaderConstants.CONTENT_TYPE + ': multipart/mixed;charset="utf-8";boundary=' + changesetBoundary + '\n\n';
 
   for (var operation in this.operations) {
     body += '--' + changesetBoundary + '\n';
@@ -165,10 +164,10 @@ BatchServiceClient.prototype.commitBatch = function (optionsOrCallback, callback
     .withOkCode(HttpConstants.HttpResponseCodes.ACCEPTED_CODE)
     .withRawResponse(true);
 
-  webResource.addOptionalHeader(HeaderConstants.CONTENT_TYPE, 'multipart/mixed; boundary=' + batchBoundary);
+  webResource.addOptionalHeader(HeaderConstants.CONTENT_TYPE, 'multipart/mixed;charset="utf-8";boundary=' + batchBoundary);
   webResource.addOptionalHeader(HeaderConstants.DATA_SERVICE_VERSION, '1.0;NetFx');
   webResource.addOptionalHeader(HeaderConstants.MAX_DATA_SERVICE_VERSION, '2.0;NetFx');
-  webResource.addOptionalHeader(HeaderConstants.CONTENT_LENGTH, body.length);
+  webResource.addOptionalHeader(HeaderConstants.CONTENT_LENGTH, Buffer.byteLength(body, 'utf8'));
 
   var self = this;
 


### PR DESCRIPTION
add utf8 encoding to the contant type and get the correct string length from Buffer.byteLength()
