### PR TITLE
bugfixing: tableservice.commitBatch() do no support utf-8 encoding

### DIFF
--- a/lib/services/table/batchserviceclient.js
+++ b/lib/services/table/batchserviceclient.js
@@ -102,7 +102,8 @@ BatchServiceClient.prototype.addOperation = function (webResource, outputData) {
     if (webResource.httpVerb !== ServiceClient.HTTP_VERB_DELETE) {
       webResource.headers[HeaderConstants.CONTENT_TYPE] = 'application/atom+xml;charset="utf-8";type=entry';
     }
-    webResource.headers[HeaderConstants.CONTENT_LENGTH] = Buffer.byteLength(outputData, 'utf8'); //outputData.length;
+    
+    webResource.headers[HeaderConstants.CONTENT_LENGTH] = Buffer.byteLength(outputData, 'utf8');
   }
 
   this._setRequestUrl(webResource);


### PR DESCRIPTION
but insertEntity and updateEntity does.

add utf8 encoding to the contant type and get the correct string length from Buffer.byteLength().

all unit tests passed.
self tests passed.
