### PR TITLE
Switching to list reporter for node test suite.

### DIFF
--- a/test/runtests.js
+++ b/test/runtests.js
@@ -62,6 +62,9 @@ files.forEach(function (file) {
 if (coverageOption !== -1) {
   args.push('-R');
   args.push('html-cov');
+} else {
+  args.push('-R');
+  args.push('List');
 }
 
 require('../node_modules/mocha/bin/mocha');


### PR DESCRIPTION
I've found it helpful to use the list reporter by default instead of the dots when running the test suite. This change makes that the default for npm test.
