### PR TITLE
fix entity group transactions with delete commands: don't send a content-type header for thse

### DIFF
--- a/lib/services/table/batchserviceclient.js
+++ b/lib/services/table/batchserviceclient.js
@@ -96,11 +96,13 @@ BatchServiceClient.prototype.addOperation = function (webResource, outputData) {
     outputData = '';
   }
 
-  if (webResource.httpVerb !== ServiceClient.HTTP_VERB_GET) {
+  if (webResource.httpVerb !== 'GET') {
     webResource.headers[HeaderConstants.CONTENT_ID] = this.operations.length + 1;
 
-    if (webResource.httpVerb !== ServiceClient.HTTP_VERB_DELETE) {
+    if (webResource.httpVerb !== 'DELETE') {
       webResource.headers[HeaderConstants.CONTENT_TYPE] = 'application/atom+xml;type=entry';
+    } else {
+      delete webResource.headers[HeaderConstants.CONTENT_TYPE];
     }
 
     webResource.headers[HeaderConstants.CONTENT_LENGTH] = outputData.length;


### PR DESCRIPTION
Entity group transactions containing delete operations fail, and it appears to be because there's a content-type header (despite there being no content).

Also note that the original code referred to properties that don't seem to exist (ServiceClient.HTTP_VERB_*), so I just put the string constants in there instead ('GET' and 'DELETE').

On a side-note, it's probably wrong to include the content-length on a delete, but that didn't seem to cause an error, so I didn't touch that. This seemed to me to be close to the minimal change necessary to fix the bug.
