### PR TITLE
allow empty strings for partition keys and row keys

### DIFF
--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -842,7 +842,7 @@ TableService.prototype._performRequestExtended = function (webResource, rawData,
 function getEntityPath(tableName, partitionKey, rowKey) {
   var path = '/' + tableName;
 
-  if (partitionKey && rowKey) {
+  if (typeof(partitionKey) === 'string' && typeof(rowKey) === 'string') {
     path = path + "(PartitionKey='" + partitionKey + "',RowKey='" + rowKey + "')";
   } else {
     throw new Error(TableService.incorrectPartitionErr);


### PR DESCRIPTION
Dev Estimate: 0.5
Test Estimate: 2

The test `if (partitionKey && rowKey)` meant the strings had to be non-empty. This fix allows empty strings.

Side-effect: You used to be able to pass other things (like an integer) as a key. Now it strictly has to be a string. This is probably a good thing, but it's a breaking change.

An alternative (non-breaking) change would be something like `if ((partitionKey || (partitionKey) === '') && (rowKey || (rowKey === ''))`. That leaves the existing test in place but also tolerates empty strings. I have to say I prefer the breaking change, since these should really always be strings.
