### PR TITLE
In case of inputStream, invoke callback on response event

### DIFF
--- a/lib/services/core/serviceclient.js
+++ b/lib/services/core/serviceclient.js
@@ -180,15 +180,12 @@ ServiceClient.prototype._performRequest = function (webResource, body, options, 
       self.logger.log(Logger.LogLevels.DEBUG, "FINAL REQUEST OPTIONS:\n" + util.inspect(finalRequestOptions));
 
       var processResponseCallback = function (error, response, responseBody) {
+
         var responseObject;
 
         if (error) {
           responseObject = { error: error, response: null };
         } else {
-          if (!(body && body.inputStream)) {
-            response.body = responseBody;
-          }
-
           responseObject = self._processResponse(webResource, response);
         }
 
@@ -196,17 +193,25 @@ ServiceClient.prototype._performRequest = function (webResource, body, options, 
       };
 
       var requestStream;
-      if (body && body.outputStream) {
-        requestStream = request(finalRequestOptions, processResponseCallback);
-        body.outputStream.pipe(requestStream);
-      } else {
+
+      if (!(body && body.outputStream)) {
         finalRequestOptions.body = body.outputData;
-        requestStream = request(finalRequestOptions, processResponseCallback);
       }
 
       if (body && body.inputStream) {
+        requestStream = request(finalRequestOptions);
+        requestStream.on('response', function(response) {
+          processResponseCallback(null, response);
+        });
         requestStream.pipe(body.inputStream);
+      } else {
+        requestStream = request(finalRequestOptions, processResponseCallback);
       }
+
+      if (body && body.outputStream) {
+        body.outputStream.pipe(requestStream);
+      }
+      
     };
 
     // The filter will do what it needs to the requestOptions and will provide a


### PR DESCRIPTION
A suggested improvement for the fix in #251.  In the case of an inputStream, invoke callback on the 'response' event instead of waiting for the entire response to arrive.  In this case, the callback will contain the response but not the responseBody.  This should be ok, however, since the body is being sent to the stream.  Also, there was already an 'if' statement in the callback to skip assigning the body when an inputStream existed (I assume this 'if' statement is no longer necessary so I removed it).

The existing fix for #251 helps, but does not solve the entire problem for me.  However since #251 added 'request', it made it easier to act on the arrival of the response prior to the arrival of the entire body.

Thanks!
