### PR TITLE
Safe array enumeration by using forEach method

### DIFF
--- a/lib/services/table/batchserviceclient.js
+++ b/lib/services/table/batchserviceclient.js
@@ -203,7 +203,8 @@ BatchServiceClient.prototype.commitBatch = function (optionsOrCallback, callback
 BatchServiceClient.prototype.processResponse = function (responseObject, requestOperations) {
   var self = this;
   var responses = null;
-  if (responseObject && responseObject.response && responseObject.response.body) {
+  if (responseObject && responseObject.response && responseObject.response.body &&
+      typeof responseObject.response.body === 'string' ) {
     responses = [];
     var rawResponses = responseObject.response.body.split(Constants.CHANGESET_DELIMITER);
 


### PR DESCRIPTION
This fixes issue #333

Enumerating all object properties is error prone and may pick up properties that are not array indexes.

Please, notice that you have the same bug in many other files. I would recommend to go over all code and fix array enumeration.

Best regards,
@yosefd
