### PR TITLE
added support for udp endpoints

### DIFF
--- a/lib/cli/commands/vm.js
+++ b/lib/cli/commands/vm.js
@@ -260,12 +260,17 @@ exports.init = function(cli) {
     .option('-s, --subscription <id>', 'use the subscription id')
     .option('-d, --dns-name <name>', 'only show VMs for this DNS name')
     .option('-n, --endpoint-name <name>', 'specify endpoint name')
+    .option('-e, --endpoint-protocol <protocol>', 'allowed protocols are tcp(default) and udp')
     .option('-b, --lb-set-name <name>', 'specify load-balancer set name')
     .option('-t, --probe-port <port>', 'VM port to use to inspect the role availability status')
     .option('-r, --probe-protocol <protocol>', 'protocol to use to inspect the role availability status')
     .option('-p, --probe-path <path>', 'relative path to inspect the role availability status')
     .execute(function(vmName, lbport, vmport, options, callback) {
-
+  
+      var endpointProtocol = options.endpointProtocol || 'tcp';
+      if(endpointProtocol !== 'tcp' && endpointProtocol !== 'udp'){
+        callback('Possible values for --endpoint-protocol are tcp and udp')
+      }
       var lbPortAsInt = parseInt(lbport, 10);
       if ((lbport != lbPortAsInt) || (lbPortAsInt > 65535)) {
         callback('lb-port must be an integer less than or equal to 65535');
@@ -316,6 +321,7 @@ exports.init = function(cli) {
         subscription: options.subscription,
         name: vmName,
         endpointName : options.endpointName,
+        endpointProtocol: endpointProtocol,
         dnsPrefix: utils.getDnsPrefix(options.dnsName, true),
         lbport: lbPortAsInt,
         vmport: vmportAsInt,
@@ -331,10 +337,15 @@ exports.init = function(cli) {
     .whiteListPowershell()
     .usage('<vm-name> <vm-port>')
     .description('Delete an azure VM endpoint')
+    .option('-e, --endpoint-protocol <protocol>', 'allowed protocols are tcp(default) and udp')
     .option('-s, --subscription <id>', 'use the subscription id')
     .option('-d, --dns-name <name>', 'only show VMs for this DNS name')
     .execute(function(vmName, vmport, options, callback) {
 
+      var endpointProtocol = options.endpointProtocol || 'tcp';
+      if(endpointProtocol !== 'tcp' && endpointProtocol !== 'udp'){
+        callback('Possible values for --endpoint-protocol are tcp and udp')
+      }
       var vmPortAsInt = parseInt(vmport, 10);
       if ((vmport != vmPortAsInt) || (vmPortAsInt > 65535)) {
         callback('vm-port must be an integer less than or equal to 65535');
@@ -343,6 +354,7 @@ exports.init = function(cli) {
       endpointCreateDelete({
         subscription: options.subscription,
         name: vmName,
+        endpointProtocol: endpointProtocol,
         dnsPrefix: utils.getDnsPrefix(options.dnsName, true),
         lbport: -1,
         vmport: vmPortAsInt,
@@ -1539,6 +1551,9 @@ exports.init = function(cli) {
               var message = null;
               // Check for the existance of endpoint
               for (; m < endpointCount; m++) {
+              
+                if(configurationSets[k].InputEndpoints[m].Protocol !== options.endpointProtocol) continue;
+                
                 var lbPortAsInt = parseInt(configurationSets[k].InputEndpoints[m].Port, 10);
                 if (!options.lbsetname && (lbPortAsInt === options.lbport)) {
                   message = 'The port ' + options.lbport + ' of load-balancer is already mapped to port ' +
@@ -1565,7 +1580,7 @@ exports.init = function(cli) {
                 if (options.create) {
                   var inputEndPoint = {
                     Name: options.endpointName || 'endpname-' + options.lbport + '-' + options.vmport,
-                    Protocol: 'tcp',
+                    Protocol: options.endpointProtocol,
                     Port: options.lbport,
                     LocalPort: options.vmport
                   };
@@ -1658,6 +1673,7 @@ exports.init = function(cli) {
               row.cell('Name', item.Name);
               row.cell('External Port', item.PublicPort);
               row.cell('Local Port', item.LocalPort);
+              row.cell('Protocol', item.Protocol);
             });
           }
         } else {


### PR DESCRIPTION
The endpoint protocol was hardcoded to tcp. With this change, creating and deleting of udp and tcp endpoints is now possible by using the flag --endpoint-protocol. By defaulting to the tcp protocol, previous code will not break.    
