### PR TITLE
Fix for tableservice batch commit error handling

### DIFF
--- a/lib/services/table/batchserviceclient.js
+++ b/lib/services/table/batchserviceclient.js
@@ -181,7 +181,15 @@ BatchServiceClient.prototype.commitBatch = function (optionsOrCallback, callback
 
   var processResponseCallback = function (responseObject, next) {
     var responseObjects = self.processResponse(responseObject, requestOperations);
-    responseObject.operationResponses = responseObjects;
+    // @see http://www.odata.org/documentation/batch#FormatOfABatchResponse
+    // The body of a ChangeSet response is either a response for all the successfully processed change 
+    // requests within the ChangeSet, formatted exactly as it would have appeared outside of a batch, 
+    // or a single response indicating a failure of the entire ChangeSet.
+    if (responseObjects && responseObjects.length > 0 && !responseObjects[0].isSuccessful) {
+      responseObject = responseObjects[0];
+    } else {
+      responseObject.operationResponses = responseObjects;
+    }
 
     var finalCallback = function (returnObject) {
       // perform final callback


### PR DESCRIPTION
When an entity within a batch commit causes a failure (e.g. out-of-date etag and {checkEtag: true} is used in an update operation), the error is not surfaced by the SDK correctly.

The format of batch error responses is described here (only a single error response is returned regardless of size of batch):
http://www.odata.org/documentation/batch#FormatOfABatchResponse

Here's an example raw response for a failing batch commit. Note that the response itself is a 2XX because the batch was accepted for processing, but the body is a single error response that should be returned via the API to the caller. Currently, this doesn't happen and the error argument to the callback provided to commitBatch() is always null.

---

HTTP/1.1 202 Accepted
Cache-Control: no-cache
Transfer-Encoding: chunked
Content-Type: multipart/mixed; boundary=batchresponse_f718542f-ca7e-4fb8-b864-3a8ac7f2bb1a
Server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: 8aa821c2-9c47-4e66-85b4-d40e8ca61ab6
x-ms-version: 2011-08-18
Date: Sun, 17 Mar 2013 04:21:29 GMT

341
--batchresponse_f718542f-ca7e-4fb8-b864-3a8ac7f2bb1a
Content-Type: multipart/mixed; boundary=changesetresponse_d865c58e-8a77-4559-9216-21fcbcebe6f7

--changesetresponse_d865c58e-8a77-4559-9216-21fcbcebe6f7
Content-Type: application/http
Content-Transfer-Encoding: binary

HTTP/1.1 400 Bad Request
Content-ID: 2
DataServiceVersion: 1.0;
Content-Type: application/xml

<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<error xmlns="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
  <code>InvalidInput</code>
  <message xml:lang="en-US">1:One of the request inputs is not valid.
RequestId:8aa821c2-9c47-4e66-85b4-d40e8ca61ab6
Time:2013-03-17T04:21:30.0560112Z</message>
</error>
--changesetresponse_d865c58e-8a77-4559-9216-21fcbcebe6f7--
--batchresponse_f718542f-ca7e-4fb8-b864-3a8ac7f2bb1a--
