### PR TITLE
(queueservice.js) Don't add ContentLength if no content was specified.

### DIFF
--- a/lib/services/queue/queueservice.js
+++ b/lib/services/queue/queueservice.js
@@ -655,7 +655,7 @@ QueueService.prototype.updateMessage = function (queue, messageid, popreceipt, v
   
   var webResource = WebResource.put(queue + '/messages/' + messageid)
     .withHeader(HeaderConstants.CONTENT_TYPE, 'application/atom+xml;charset="utf-8"')
-    .withHeader(HeaderConstants.CONTENT_LENGTH, contentLength);
+    .withHeader(HeaderConstants.CONTENT_LENGTH, contentLength)
     .withQueryOption(QueryStringConstants.POP_RECEIPT, popreceipt, null, true)
     .withQueryOption(QueryStringConstants.VISIBILITY_TIMEOUT, visibilitytimeout)
     .withBody(content);


### PR DESCRIPTION
(re-opening against dev as requested)

QueueService::updateMessage should be able to handle a plain visibilitytimeout update without having to change the message as well (as per the docs in the code).

It's setup to do that, apart from it trying to add the content length to the request when the content === null.

I don't think this fix is right, mainly because the CONTENT_TYPE is still being sent, but it does work and thought it could be the right starting point if someone could point me in the right direction for fixing this well enough to be accepted.

Finally, I'd love to write a testcase however there are no docs in how to run the tests and/or the environment needed. If you could point me to some I'll make sure there's a test too.
