### PR TITLE
Adding support to ServiceManagement for role operations Reboot and Reima...

### DIFF
--- a/examples/servicemanagement/testrebootreimage.js
+++ b/examples/servicemanagement/testrebootreimage.js
@@ -1,0 +1,97 @@
+/**
+* Copyright (c) Microsoft.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+var fs = require('fs');
+var azure = require('../../lib/azure');
+var Constants = require('../../lib/util/constants');
+var HttpResponseCodes = Constants.HttpConstants.HttpResponseCodes;
+var testCommon = require('./testcommon');
+
+if (!fs.existsSync) {
+  fs.existsSync = require('path').existsSync;
+}
+
+if (fs.existsSync('./testhost.json')) {
+  inp = JSON.parse(fs.readFileSync('./testhost.json'));
+} else {
+  console.log('The file testhost.json was not found.\n' +
+              'This is required and must specify the host, the subscription id, and the certificate file locations');
+}
+
+inp.hostopt.serializetype = 'XML';
+var svcmgmt = azure.createServiceManagementService(inp.subscriptionId, inp.auth, inp.hostopt);
+
+var inputNames = {
+  serviceName: 'testjsSvc',
+  deploymentName: 'testjsDeploy',
+  deploymentSlot: 'Staging',
+  roleInst: 'testjsRole_IN_0',
+};
+
+
+if (process.argv.length < 3) {
+  console.log('Pass either reboot or reimage on the command line');
+  process.exit();
+}
+
+var reqid = process.argv[2];
+
+
+if (reqid.toLowerCase() == 'reboot') {
+  svcmgmt.rebootRole(inputNames.serviceName,
+                                inputNames.deploymentSlot,
+                                inputNames.roleInst,
+                                function(error, response) {
+    if (error) {
+      testCommon.showErrorResponse(error);
+    } else {
+      if (response && response.isSuccessful) {
+        if (response.statusCode == HttpResponseCodes.Ok) {
+          console.log('OK');
+        } else {
+          console.log('Pending');
+          console.log('RequestID: ' + response.headers['x-ms-request-id']);
+        }
+      } else {
+        console.log('Unexpected');
+      }
+    }
+  });
+} else if (reqid.toLowerCase() == 'reimage') {
+  svcmgmt.reimageRole(inputNames.serviceName,
+                                inputNames.deploymentSlot,
+                                inputNames.roleInst,
+                                function(error, response) {
+    if (error) {
+      testCommon.showErrorResponse(error);
+    } else {
+      if (response && response.isSuccessful) {
+        if (response.statusCode == HttpResponseCodes.Ok) {
+          console.log('OK');
+        } else {
+          console.log('Pending');
+          console.log('RequestID: ' + response.headers['x-ms-request-id']);
+        }
+      } else {
+        console.log('Unexpected');
+      }
+    }
+  });
+} else {
+  console.log('Pass either reboot or reimage on the command line');
+  process.exit();
+}
+
+

--- a/lib/services/serviceManagement/models/servicemanagementserialize.js
+++ b/lib/services/serviceManagement/models/servicemanagementserialize.js
@@ -573,6 +573,52 @@ ServiceManagementSerialize.prototype.buildStartRole = function (serviceName, dep
 };
 
 /**
+* Create the message body for RebootRole
+*   Use the specified serialization - for now only XML
+*
+* @param {string} serviceName       The name of the service.
+* @param {string} deploymentSlot    The name of the deploymentSlot (Production or Staging).
+* @param {string} roleName          The name of the role instance.
+* @param {object} client            The servicemanagement object.
+*/
+ServiceManagementSerialize.prototype.buildRebootRole = function (serviceName, deploymentSlot,
+                                                    roleName, client) {
+  if (client.serializetype === 'XML') {
+    var doc = _createXmlRoot('RebootRoleOperation');
+    doc.ele('OperationType').txt('RebootRoleOperation');
+    return doc.toString();
+  } else {
+    var jdoc = {};
+    jdoc.OperationType = 'RebootRoleOperation';
+
+    return JSON.stringify(jdoc);
+  }
+};
+
+/**
+* Create the message body for ReimageRole
+*   Use the specified serialization - for now only XML
+*
+* @param {string} serviceName       The name of the service.
+* @param {string} deploymentSlot    The name of the deploymentSlot (Production or Staging).
+* @param {string} roleName          The name of the role instance.
+* @param {object} client            The servicemanagement object.
+*/
+ServiceManagementSerialize.prototype.buildReimageRole = function (serviceName, deploymentSlot,
+                                                    roleName, client) {
+  if (client.serializetype === 'XML') {
+    var doc = _createXmlRoot('ReimageRoleOperation');
+    doc.ele('OperationType').txt('ReimageRoleOperation');
+    return doc.toString();
+  } else {
+    var jdoc = {};
+    jdoc.OperationType = 'ReimageRoleOperation';
+
+    return JSON.stringify(jdoc);
+  }
+};
+
+/**
 * Create the message body for RestartRole
 *   Use the specified serialization - for now only XML
 *

--- a/lib/services/serviceManagement/servicemanagementservice.js
+++ b/lib/services/serviceManagement/servicemanagementservice.js
@@ -1568,6 +1568,74 @@ ServiceManagementService.prototype.startRole = function (serviceName, deployment
 };
 
 /**
+* Request a reboot on the specified role
+*
+* @param {string} serviceName           The name of the hosted service. Required.
+* @param {string} deploymentSlot        The name of the slot (Production or Staging). Required.
+* @param {string} roleInst              The role instance name. Required.
+* @param {function} callback            The callback function called on completion. Required.
+*/
+ServiceManagementService.prototype.rebootRole = function (serviceName, deploymentSlot,
+                                                      roleInst, callback) {
+  validateStringArgument(serviceName, 'serviceName', 'rebootRole');
+  validateStringArgument(deploymentSlot, 'deploymentSlot', 'rebootRole');
+  validateStringArgument(roleInst, 'roleInst', 'rebootRole');
+  validateObjectArgument(callback, 'callback', 'rebootRole');
+
+  var path = '/' + this.subscriptionId + '/services/hostedservices/' +
+             serviceName + '/deploymentslots/' +
+             deploymentSlot + '/roleinstances/' +
+             roleInst + '?comp=reboot';
+
+  var webResource = WebResource.post(path);
+  webResource.withOkCode(HttpConstants.HttpResponseCodes.Accepted, true);
+  var outbody = this.serialize.buildRebootRole(serviceName, deploymentSlot,
+                                                roleInst, this);
+
+  this.performRequest(webResource, outbody, null, function (responseObject, next) {
+    var finalCallback = function (returnObject) {
+      callback(returnObject.error, returnObject.response);
+    };
+
+    next(responseObject, finalCallback);
+  });
+};
+
+/**
+* Request a reimage on the specified role
+*
+* @param {string} serviceName           The name of the hosted service. Required.
+* @param {string} deploymentSlot        The name of the slot (Production or Staging). Required.
+* @param {string} roleInst              The role instance name. Required.
+* @param {function} callback            The callback function called on completion. Required.
+*/
+ServiceManagementService.prototype.reimageRole = function (serviceName, deploymentSlot,
+                                                      roleInst, callback) {
+  validateStringArgument(serviceName, 'serviceName', 'reimageRole');
+  validateStringArgument(deploymentSlot, 'deploymentSlot', 'reimageRole');
+  validateStringArgument(roleInst, 'roleInst', 'reimageRole');
+  validateObjectArgument(callback, 'callback', 'reimageRole');
+
+  var path = '/' + this.subscriptionId + '/services/hostedservices/' +
+             serviceName + '/deploymentslots/' +
+             deploymentSlot + '/roleinstances/' +
+             roleInst + '?comp=reimage';
+
+  var webResource = WebResource.post(path);
+  webResource.withOkCode(HttpConstants.HttpResponseCodes.Accepted, true);
+  var outbody = this.serialize.buildReimageRole(serviceName, deploymentSlot,
+                                                roleInst, this);
+
+  this.performRequest(webResource, outbody, null, function (responseObject, next) {
+    var finalCallback = function (returnObject) {
+      callback(returnObject.error, returnObject.response);
+    };
+
+    next(responseObject, finalCallback);
+  });
+};
+
+/**
 * Request a restart on the specified role
 *
 * @param {string} serviceName           The name of the hosted service. Required.


### PR DESCRIPTION
The service management API does not have support for all PaaS operations, RebootRole and ReimageRole being two that are missing and I require.  I modified ServiceManagementService.js and the corresponding ServiceManagementSerialize.js method to add support for both of these operations.  I also added an example test for this functionality.  I used RestartRole as an example for the code changes as well as test changes.
