### PR TITLE
Fix for network configuration serialization for Subnets

### DIFF
--- a/lib/services/serviceManagement/models/servicemanagementserialize.js
+++ b/lib/services/serviceManagement/models/servicemanagementserialize.js
@@ -974,11 +974,11 @@ ServiceManagementSerialize.prototype._buildNetworkConfigurationXml = function (c
   }
 
   if (cfgset.SubnetNames) {
-    var subs = node.ele('SubnetNames');
+    var subs = child.ele('SubnetNames');
     var alen = cfgset.SubnetNames.length;
 
     for (var i = 0; i < alen; i++) {
-      _addDefinedValueXml(subs, 'string', cfgset.SubnetNames[i].string);
+      _addDefinedValueXml(subs, 'SubnetName', cfgset.SubnetNames[i]);
     }
   }
 };


### PR DESCRIPTION
Hi, this is a patch for the issue creating an endpoint on a VM if it is part of a VNet:

https://github.com/WindowsAzure/azure-sdk-tools-xplat/issues/543
