### PR TITLE
Updating zumo version to point to SDK 0.7.7 for GCM notification hub support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "engines": { "node": ">= 0.6.15" },
   "licenses": [ { "type": "Apache", "url": "http://www.apache.org/licenses/LICENSE-2.0" } ],
   "dependencies": {
-    "azure": "git://github.com/WindowsAzure/azure-sdk-for-node.git#v0.7.5-May2013",
+    "azure": "git://github.com/WindowsAzure/azure-sdk-for-node.git#v0.7.7-June2013",
     "xml2js": "0.1.14",
     "sax": "0.4.2",
     "qs": "0.5.1",


### PR DESCRIPTION
Issue #823 
