### PR TITLE
Added error check in notification hub setup files

### DIFF
--- a/test/services/serviceBus/apnsservice-tests.js
+++ b/test/services/serviceBus/apnsservice-tests.js
@@ -54,6 +54,7 @@ describe('APNS notifications', function () {
   beforeEach(function (done) {
     suiteUtil.setupTest(function () {
       service.listNotificationHubs(function (err, hubs) {
+        should.not.exist(err);
         var xplatHubs = hubs.filter(function (hub) {
           return hub.NotificationHubName.substr(0, hubNamePrefix.length) === hubNamePrefix;
         });
@@ -95,7 +96,7 @@ describe('APNS notifications', function () {
     });
 
     it('should send a simple message', function (done) {
-      notificationHubService.apns.send(null, { 
+      notificationHubService.apns.send(null, {
         alert: 'This is my toast message for iOS!'
       }, function (error, result) {
         should.not.exist(error);

--- a/test/services/serviceBus/gcmservice-tests.js
+++ b/test/services/serviceBus/gcmservice-tests.js
@@ -54,6 +54,7 @@ describe('GCM notifications', function () {
   beforeEach(function (done) {
     suiteUtil.setupTest(function () {
       service.listNotificationHubs(function (err, hubs) {
+        should.not.exist(err);
         var xplatHubs = hubs.filter(function (hub) {
           return hub.NotificationHubName.substr(0, hubNamePrefix.length) === hubNamePrefix;
         });

--- a/test/services/serviceBus/mpnsservice-tests.js
+++ b/test/services/serviceBus/mpnsservice-tests.js
@@ -52,6 +52,7 @@ describe('MPNS notifications', function () {
   beforeEach(function (done) {
     suiteUtil.setupTest(function () {
       service.listNotificationHubs(function (err, hubs) {
+        should.not.exist(err);
         var xplatHubs = hubs.filter(function (hub) {
           return hub.NotificationHubName.substr(0, hubNamePrefix.length) === hubNamePrefix;
         });

--- a/test/services/serviceBus/wnsservice-tests.js
+++ b/test/services/serviceBus/wnsservice-tests.js
@@ -52,6 +52,7 @@ describe('WNS notifications', function () {
   beforeEach(function (done) {
     suiteUtil.setupTest(function () {
       service.listNotificationHubs(function (err, hubs) {
+        should.not.exist(err);
         var xplatHubs = hubs.filter(function (hub) {
           return hub.NotificationHubName.substr(0, hubNamePrefix.length) === hubNamePrefix;
         });


### PR DESCRIPTION
When there's an error in the listing of hubs as part of the test setup, tests don't check for the error and blindly continue. This leaves us with "can't call filter on undefined" and loses the individual errors.
