### PR TITLE
Fix for xplat issue #809

### DIFF
--- a/lib/services/serviceManagement/websitemanagementservice.js
+++ b/lib/services/serviceManagement/websitemanagementservice.js
@@ -214,7 +214,7 @@ WebsiteManagementService.prototype.createPublishingUser = function (username, pa
 
   this.performRequest(webResource, publishingUserXml, null, function (responseObject, next) {
     // TODO: temporary workaround for an invalid return code
-    if (responseObject.error != null && responseObject.error.code === 'Unauthorized') {
+    if (responseObject.error !== null && responseObject.error.code === 'Unauthorized') {
       responseObject.error = null;
     }
 


### PR DESCRIPTION
This fixes an issue when the publishinguser call actually succeeds - this happens in the latest antares version on rdfenext.

Without it, we return a nasty null reference error if the call succeeds.
