### PR TITLE
LoadBalancerProbe Path can be NULL if the transport is TCP

### DIFF
--- a/lib/services/serviceManagement/models/roleschema.json
+++ b/lib/services/serviceManagement/models/roleschema.json
@@ -378,7 +378,7 @@
                               "Path":
                                 {
                                   "Name": "Path",
-                                  "Required": true,
+                                  "Required": false,
                                   "Type": "Primitive.String",
                                   "RegEx": "NIL",
                                   "XmlNode": "Path"


### PR DESCRIPTION
Importing and Exporting a LoadBalanced VM with a TCP transport fails on the import due to incorrect input validation. The validation could be a bit stricter, or conditional, but I don't know if there there is a facility for that yet.

Reference: http://msdn.microsoft.com/en-us/library/windowsazure/jj157194.aspx
