### PR TITLE
enabling jsdoc template & build config

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -25,8 +25,8 @@ module.exports = function(grunt) {
             ], 
             options: {
                 destination: 'docs',
-                // configure: 'jsdoc/jsdoc.json',
-                // template: 'jsdoc/template'
+                configure: 'jsdoc/jsdoc.json',
+                template: 'jsdoc/template'
             }
         }
     },


### PR DESCRIPTION
enabling template + config so we get markdown enabled comments for jsdoc.
