### PR TITLE
Fixing issue #1045

### DIFF
--- a/test/services/blob/blobservice-tests.js
+++ b/test/services/blob/blobservice-tests.js
@@ -1356,33 +1356,6 @@ describe('BlobService', function () {
 
       done();
     });
-
-    it('GenerateSharedAccessSignatureForBlobWithSpaceInName', function (done) {
-      var containerName = 'images';
-      var blobName = 'pic1 copy.png';
-
-      var devStorageBlobService = azure.createBlobService(ServiceClientConstants.DEVSTORE_STORAGE_ACCOUNT, ServiceClientConstants.DEVSTORE_STORAGE_ACCESS_KEY);
-
-      var sharedAccessPolicy = {
-        AccessPolicy: {
-          Permissions: BlobConstants.SharedAccessPermissions.READ,
-          Start: new Date('October 11, 2011 11:03:40 am GMT'),
-          Expiry: new Date('October 12, 2011 11:53:40 am GMT')
-        }
-      };
-
-      var sharedAccessSignature = devStorageBlobService.generateSharedAccessSignature(containerName, blobName, sharedAccessPolicy);
-
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNED_START], '2011-10-11T11:03:40Z');
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNED_EXPIRY], '2011-10-12T11:53:40Z');
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNED_RESOURCE], BlobConstants.ResourceTypes.BLOB);
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNED_PERMISSIONS], BlobConstants.SharedAccessPermissions.READ);
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNED_VERSION], '2012-02-12');
-      assert.equal(sharedAccessSignature.queryString[QueryStringConstants.SIGNATURE], 'rHyhgZto/4+LvdTYwsd/vuevqAfiglSuAsrm7tkeBrE=');
-
-      done();
-    });
-
   });
 
   it('responseEmits', function (done) {


### PR DESCRIPTION
Fixing issue WindowsAzure#1045. Shared access signatures need to be generated using unencoded blob names, but previously the code tried to do it with an encoded blob name, generating a signature different from what was expected and causing authorization failures.
