### PR TITLE
Fixed Issue #1109

### DIFF
--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -16,7 +16,7 @@
 var _ = require('underscore');
 
 var azureutil = require('./util');
-var check = require('validator').check;
+var check = require('validator');
 
 exports = module.exports;
 
@@ -46,7 +46,7 @@ function initCallback(callbackParam, resultsCb) {
 exports.isValidUri = function (uri) {
   try {
     // Check will throw if it is not valid.
-    check(uri).isUrl();
+    check.isURL(uri);
     return true;
   } catch (e) {
     throw new Error('The provided URI "' + uri + '" is invalid.');

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-uuid": "> = 1.2.0",
     "tunnel": ">= 0.0.1",
     "request": "2.27.0",
-    "validator": ">= 0.4.12",
+    "validator": "3.1.0",
     "wns": ">= 0.5.3",
     "mpns": ">= 2.0.0",
     "envconf": ">= 0.0.4",


### PR DESCRIPTION
The uncaught exception was caused due to the change in the validator API. 

The package.json has been amended to lock the validator version to new api, since the call signature is different.

util.js has been edited to conform to new invocation methods.
