### PR TITLE
Support CustomData

### DIFF
--- a/lib/services/management/lib/models/roleschema.json
+++ b/lib/services/management/lib/models/roleschema.json
@@ -217,7 +217,15 @@
                             "XmlNode": "Thumbprint"
                           }
                       }
-                  }
+                  },
+              "CustomData":
+                {
+                  "Name": "CustomData",
+                  "Required": false,
+                  "Type": "Primitive.String",
+                  "RegEx": "NIL",
+                  "XmlNode": "CustomData"
+                }
             },
           "LinuxProvisioningConfiguration": 
             {
@@ -325,7 +333,15 @@
                              }
                          }
                      }
-                 }
+                 },
+              "CustomData":
+                {
+                  "Name": "CustomData",
+                  "Required": false,
+                  "Type": "Primitive.String",
+                  "RegEx": "NIL",
+                  "XmlNode": "CustomData"
+                }
             },
           "NetworkConfiguration": 
             {

--- a/lib/services/management/lib/servicemanagementservice.js
+++ b/lib/services/management/lib/servicemanagementservice.js
@@ -196,7 +196,7 @@ function ServiceManagementService(configOrSubscriptionId, authentication, hostOp
   ServiceManagementService['super_'].call(this, settings);
   // TODO: Remove below version setting and update 'ServiceManagementClient' to new version once all
   // commands having dependency on ServiceManagementClient updated to use newer version '2013-06-01'.
-  this.apiversion = '2013-06-01';
+  this.apiversion = '2013-10-01';
 
   this.subscriptionId = settings._subscriptionId;
   this.serialize = new ServiceManagementSerialize();


### PR DESCRIPTION
As of the latest fabric update a new element called "CustomData" can be
defined for the Windows/Linux Provisioning Configuration data:
http://msdn.microsoft.com/en-us/library/windowsazure/jj157194.aspx

Per the API documentation, we must also update the API version to
2013-10-01 to set the CustomData element.
