### PR TITLE
Reimage role instance API call by slot/name should not have a request body

### DIFF
--- a/lib/services/computeManagement/lib/computeManagementClient.js
+++ b/lib/services/computeManagement/lib/computeManagementClient.js
@@ -1312,6 +1312,7 @@ var DeploymentOperations = ( /** @lends DeploymentOperations */ function() {
     httpRequest.method = 'POST';
     httpRequest.headers = {};
     httpRequest.url = url2;
+	httpRequest.body = null;	
     
     // Set Headers
     httpRequest.headers['Content-Length'] = '0';
@@ -1380,6 +1381,7 @@ var DeploymentOperations = ( /** @lends DeploymentOperations */ function() {
     httpRequest.method = 'POST';
     httpRequest.headers = {};
     httpRequest.url = url2;
+	httpRequest.body = null;
     
     // Set Headers
     httpRequest.headers['Content-Length'] = '0';


### PR DESCRIPTION
MSDN documentation for Reimage Role Instance says the request body should be empty.  Also confirmed by the content-length being 0.  http://msdn.microsoft.com/en-us/library/windowsazure/gg441292.aspx

In webresource.js (https://github.com/WindowsAzure/azure-sdk-for-node/blob/master/lib/common/lib/http/webresource.js#L277) the isMethodWithBody() function assumes that if the method is a POST, then we have a body.  This seems to be true for many (most) Azure REST calls, but not the re-image calls.

Setting the body to null made my calls succeed.  Without the two new lines, the calls don't work.  
