### PR TITLE
Fixes to ChunkStream sending incorrect size and failing with oob if chunks are the wrong size.

### DIFF
--- a/lib/services/blob/internal/chunkStream.js
+++ b/lib/services/blob/internal/chunkStream.js
@@ -128,7 +128,6 @@ ChunkStream.prototype._buildChunk = function (data) {
 
     this._emitBufferData(buffer);
   } while(dataSize > 0);
-  console.log("dataSize: %s, dataOffset: %s", data.length, dataOffset);
 };
 
 


### PR DESCRIPTION
While streaming using createBlob I found two errors in the ChunkStream:

The first was that if the data.length and chunk size (_highWaterMark), were not multiples of each other, you would get an oob when trying to stream to it. (Fixed by using 'copied' instead of 'data.length' to increment the _internalBufferSize in copyToInternalBuffer).

The second was that the first copyToInternalBuffer in _buildChunk was receiving the wrong starting offset after re-syncing the frame, this was fixed by replacing '0' with 'dataOffset'.

See:  https://github.com/Azure/azure-sdk-for-node/pull/1214 
Where I was submitting this to the wrong branch.

Will have CLA in Monday.

Thanks,

-Jon
