### PR TITLE
Fixing validation strings

### DIFF
--- a/lib/services/webSiteManagement/lib/credentials/basicAuthenticationCloudCredentials.js
+++ b/lib/services/webSiteManagement/lib/credentials/basicAuthenticationCloudCredentials.js
@@ -1,18 +1,18 @@
-// 
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 var azureCommon = require('azure-common');
 var validate = azureCommon.validate;
@@ -28,8 +28,8 @@ var validate = azureCommon.validate;
 function BasicAuthenticationCloudCredentials(credentials) {
   validate.validateArgs('BasicAuthenticationCloudCredentials', function (v) {
     v.object(credentials, 'credentials');
-    v.string(credentials.username, 'credentials.subscriptionId');
-    v.string(credentials.password, 'credentials.pem');
+    v.string(credentials.username, 'credentials.username');
+    v.string(credentials.password, 'credentials.password');
   });
 
   this.credentials = credentials;


### PR DESCRIPTION
Validation strings in basicAuthorizationCloudCredentials were copy/pasted from somewhere else, made it really confusing to debug.
