### PR TITLE
Duplicate item created by TFS bridge 111

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -42,13 +42,13 @@
     "duplexer": "~0.1.1",
     "through": "~2.3.4"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/computeManagement/package.json
+++ b/lib/services/computeManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/gallery/package.json
+++ b/lib/services/gallery/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/hdinsight/package.json
+++ b/lib/services/hdinsight/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/legacyStorage/package.json
+++ b/lib/services/legacyStorage/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/management/package.json
+++ b/lib/services/management/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/monitoring/package.json
+++ b/lib/services/monitoring/package.json
@@ -35,13 +35,13 @@
     "underscore": "1.4.x",
     "moment": "2.6.0"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/networkManagement/package.json
+++ b/lib/services/networkManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/resourceManagement/package.json
+++ b/lib/services/resourceManagement/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/scheduler/package.json
+++ b/lib/services/scheduler/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "moment": "2.6.0"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/schedulerManagement/package.json
+++ b/lib/services/schedulerManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/serviceBus/package.json
+++ b/lib/services/serviceBus/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/serviceBusManagement/package.json
+++ b/lib/services/serviceBusManagement/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/sqlManagement/package.json
+++ b/lib/services/sqlManagement/package.json
@@ -34,13 +34,13 @@
     "azure-common": "0.9.6",
     "underscore": "1.4.x"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/storageManagement/package.json
+++ b/lib/services/storageManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/storeManagement/package.json
+++ b/lib/services/storeManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/subscriptionManagement/package.json
+++ b/lib/services/subscriptionManagement/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "azure-common": "0.9.6"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/webSiteManagement/package.json
+++ b/lib/services/webSiteManagement/package.json
@@ -35,13 +35,13 @@
     "underscore": "1.4.x",
     "moment": "2.6.0"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/lib/services/webSiteManagement2/package.json
+++ b/lib/services/webSiteManagement2/package.json
@@ -35,13 +35,13 @@
     "underscore": "1.4.x",
     "moment": "2.6.0"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint"

--- a/package.json
+++ b/package.json
@@ -66,13 +66,13 @@
     "grunt-jsdoc": "~0.5.1",
     "grunt-devserver": "~0.4.1"
   },
-  "homepage": "http://github.com/WindowsAzure/azure-sdk-for-node",
+  "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WindowsAzure/azure-sdk-for-node.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/WindowsAzure/azure-sdk-for-node/issues"
+    "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm -s run-script jshint && npm -s run-script unit",


### PR DESCRIPTION
Currently our package.json files all point to WindowsAzure/azure-sdk-for-node, which isn't correct anymore and the redirect is apparently fragile.

This PR updates the package.json files to point to the correct repo. Addresses issues from bug #1276.<p><a href="https://github.com/Azure/azure-sdk-for-node/pull/1277">https://github.com/Azure/azure-sdk-for-node/pull/1277</a></p>

<!---@tfsbridge:{"tfsId":2061456}-->
