### PR TITLE
ServiceBus: Implement Renew-Lock for Message

### DIFF
--- a/lib/services/serviceBus/lib/servicebusservice.js
+++ b/lib/services/serviceBus/lib/servicebusservice.js
@@ -353,6 +353,39 @@ ServiceBusService.prototype.unlockMessage = function (message, callback) {
 };
 
 /**
+* Renew-lock for message.
+*
+* @param {object|string}      message                 The message object or a string with the message location.
+* @param {Function(error, response)} callback         `error` will contain information
+*                                                     if an error occurs; otherwise `response` will contain information related to this operation.
+* @return {undefined}
+*/
+ServiceBusService.prototype.renewLockForMessage = function (message, callback) {
+  validateCallback(callback);
+
+  if (azureutil.objectIsString(message)) {
+    message = { location: message };
+  }
+
+  var relativePath = message.location.substr(
+    message.location.indexOf(ServiceClientConstants.CLOUD_SERVICEBUS_HOST + '/') +
+    ServiceClientConstants.CLOUD_SERVICEBUS_HOST.length + 1);
+
+  var webResource = WebResource.post(relativePath)
+    .withRawResponse();
+
+  var processResponseCallback = function (responseObject, next) {
+    var finalCallback = function (returnObject) {
+      callback(returnObject.error, returnObject.response);
+    };
+
+    next(responseObject, finalCallback);
+  };
+
+  this.performRequest(webResource, null, null, processResponseCallback);
+};
+
+/**
 * Sends a queue message.
 * 
 * @param {string}             queuePath                                           A string object that represents the name of the queue to which the message will be sent.

--- a/test/services/serviceBus/servicebusservice-tests.js
+++ b/test/services/serviceBus/servicebusservice-tests.js
@@ -588,6 +588,88 @@ suite('servicebusservice-tests', function () {
     });
   });
 
+  test('LockCanBeRenewedForPeekLockedMessage', function (done) {
+    var queueName = testutil.generateId(queueNamesPrefix, queueNames, suiteUtil.isMocked);
+    var messageText = 'hi there again';
+
+    serviceBusService.createQueue(queueName, function (createError, queue) {
+      assert.equal(createError, null);
+      assert.notEqual(queue, null);
+
+      serviceBusService.sendQueueMessage(queueName, messageText, function (sendError) {
+        assert.equal(sendError, null);
+
+        // Peek the message
+        serviceBusService.receiveQueueMessage(queueName, { isPeekLock: true, timeoutIntervalInS: 5 }, function (receiveError1, message1) {
+          assert.equal(receiveError1, null);
+          assert.equal(message1.body, messageText);
+
+          assert.notEqual(message1.location, null);
+          assert.notEqual(message1.brokerProperties.LockToken, null);
+          assert.notEqual(message1.brokerProperties.LockedUntilUtc, null);
+
+          // Renew lock for message
+          serviceBusService.renewLockForMessage(message1.location, function (renewLockError) {
+            assert.equal(renewLockError, null);
+
+            // deleted message
+            serviceBusService.unlockMessage(message1.location, function (unlockError) {
+              assert.equal(unlockError, null);
+
+              serviceBusService.receiveQueueMessage(queueName, function (receiveError2, receiveMessage2) {
+                assert.equal(receiveError2, null);
+                assert.notEqual(receiveMessage2, null);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  test('LockCanBeRenewedForPeekLockedMessageWithObject', function (done) {
+    var queueName = testutil.generateId(queueNamesPrefix, queueNames, suiteUtil.isMocked);
+    var messageText = 'hi there again';
+
+    serviceBusService.createQueue(queueName, function (createError, queue) {
+      assert.equal(createError, null);
+      assert.notEqual(queue, null);
+
+      serviceBusService.sendQueueMessage(queueName, messageText, function (sendError) {
+        assert.equal(sendError, null);
+
+        // Peek the message
+        serviceBusService.receiveQueueMessage(queueName, { isPeekLock: true, timeoutIntervalInS: 5 }, function (receiveError1, message1) {
+          assert.equal(receiveError1, null);
+          assert.equal(message1.body, messageText);
+
+          assert.notEqual(message1.location, null);
+          assert.notEqual(message1.brokerProperties.LockToken, null);
+          assert.notEqual(message1.brokerProperties.LockedUntilUtc, null);
+
+          // Renew lock for message
+          serviceBusService.renewLockForMessage(message1, function (renewLockError) {
+            assert.equal(renewLockError, null);
+
+            // deleted message
+            serviceBusService.unlockMessage(message1, function (unlockError) {
+              assert.equal(unlockError, null);
+
+              serviceBusService.receiveQueueMessage(queueName, function (receiveError2, receiveMessage2) {
+                assert.equal(receiveError2, null);
+                assert.notEqual(receiveMessage2, null);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   test('CreateTopic', function (done) {
     var topicName = testutil.generateId(topicNamesPrefix, topicNames, suiteUtil.isMocked);
     var topicOptions = {


### PR DESCRIPTION
Fixes (implements) #1271 
Source documentation on MSDN: [Renew-Lock for Message from Queue (Non-Destructive Read)](http://msdn.microsoft.com/en-us/library/jj839741.aspx).
Style and test coverage are largely taken from the &quot;UnlockMessage&quot; function implementation.
Tests pass OK against a real Azure service bus (with NOCK_OFF=&quot;true&quot;); I guess it won't be helpful to commit my own NOCK http recordings for the case.
CLA signed and emailed.<p><a href="https://github.com/Azure/azure-sdk-for-node/pull/1278">https://github.com/Azure/azure-sdk-for-node/pull/1278</a></p>

<!---@tfsbridge:{"tfsId":2116652}-->
