### PR TITLE
Moved missing dependencies to azure-sb module

### DIFF
--- a/lib/services/serviceBus/package.json
+++ b/lib/services/serviceBus/package.json
@@ -32,7 +32,9 @@
   ],
   "dependencies": {
     "azure-common": "0.9.7",
-    "underscore": "1.4.x"
+    "underscore": "1.4.x",
+    "wns": "~0.5.3",
+    "mpns": "~2.0.0"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "mime": "~1.2.4",
     "underscore": "1.4.x",
     "request": "2.27.0",
-    "wns": "~0.5.3",
-    "mpns": "~2.0.0",
     "node-uuid": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Without this change azure-sb won't npm install properly, but it still works if you install the whole azure module.
