### PR TITLE
A few adjustements to get the sample running

### DIFF
--- a/lib/services/webSiteManagement/README.md
+++ b/lib/services/webSiteManagement/README.md
@@ -32,9 +32,9 @@ This library support management certificate authentication. To authenticate the 
 var fs                = require('fs'),
     webSiteManagement = require('azure-mgmt-website');
 
-var webSiteManagementClient = webSiteManagement.createWebsiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
+var webSiteManagementClient = webSiteManagement.createWebSiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
-  pem: fs.readFileSync('<your pem file>')
+  pem: fs.readFileSync('<your pem file>’).toString()
 }));
 ```
 


### PR DESCRIPTION
createWebsiteManagementClient has a capital S in WebSite -> createWebSiteManagementClient

The pem-file needs a toString() to work.

<!---@tfsbridge:{"tfsId":2286796}-->
