### PR TITLE
address jshint error flagged by the latest jshint 2.5.6 released yesterday.

### DIFF
--- a/lib/serviceruntime/roleenvironment.js
+++ b/lib/serviceruntime/roleenvironment.js
@@ -602,18 +602,18 @@ RoleEnvironment._calculateChanges = function (callback) {
       var newRoles = newData.roles;
 
       var setting;
-      for (setting in currentConfig) {
+      Object.keys(currentConfig).forEach(function(settings) {
         if (!newConfig[setting] ||
             newConfig[setting] !== currentConfig[setting]) {
           changes.push({ type: 'ConfigurationSettingChange', name: setting });
         }
-      }
+      });
 
-      for (setting in newConfig) {
+      Object.keys(newConfig).forEach(function(settings) {
         if (!currentConfig[setting]) {
           changes.push({ type: 'ConfigurationSettingChange', name: setting });
         }
-      }
+      });
 
       var changedRoleSet = [];
       var role;
@@ -627,12 +627,12 @@ RoleEnvironment._calculateChanges = function (callback) {
       var newEndpoint;
 
       for (role in currentRoles) {
-        if (newRoles[role]) {
+        if (currentRoles.hasOwnProperty(role) && newRoles[role]) {
           currentRole = currentRoles[role];
           newRole = newRoles[role];
 
           for (instance in currentRole.instances) {
-            if (newRole.instances[instance]) {
+            if (currentRole.instances.hasOwnProperty(instance) && newRole.instances[instance]) {
               currentInstance = currentRole.instances[instance];
               newInstance = newRole.instances[instance];
 
@@ -640,7 +640,7 @@ RoleEnvironment._calculateChanges = function (callback) {
                   currentInstance.updateDomain === newInstance.updateDomain) {
 
                 for (endpoint in currentInstance.endpoints) {
-                  if (newInstance.endpoints[endpoint]) {
+                  if (currentInstance.endpoints.hasOwnProperty(endpoint) && newInstance.endpoints[endpoint]) {
                     currentEndpoint = currentInstance.endpoints[endpoint];
                     newEndpoint = newInstance.endpoints[endpoint];
 
@@ -666,12 +666,12 @@ RoleEnvironment._calculateChanges = function (callback) {
       }
 
       for (role in newRoles) {
-        if (currentRoles[role]) {
+        if (newRoles.hasOwnProperty(role) && currentRoles[role]) {
           currentRole = currentRoles[role];
           newRole = newRoles[role];
 
           for (instance in newRole.instances) {
-            if (currentRole.instances[instance]) {
+            if (newRole.instances.hasOwnProperty(instance) && currentRole.instances[instance]) {
               currentInstance = currentRole.instances[instance];
               newInstance = newRole.instances[instance];
 
@@ -679,7 +679,7 @@ RoleEnvironment._calculateChanges = function (callback) {
                   currentInstance.updateDomain === currentInstance.updateDomain) {
 
                 for (endpoint in newInstance.endpoints) {
-                  if (currentInstance.endpoints[endpoint]) {
+                  if (newInstance.endpoints.hasOwnProperty(endpoint) && currentInstance.endpoints[endpoint]) {
                     currentEndpoint = currentInstance.endpoints[endpoint];
                     newEndpoint = newInstance.endpoints[endpoint];
 


### PR DESCRIPTION
Quick notes:
1. this shows up in today's travis run for an unrelated PR.
2. it flags the loop of "for (setting in newConfig) {", so i am fixing it; but since i am on it, I also address other 'for-in' in a safe manner.
3. Looks like loop at #2 actually never gets hit under this context, because it appears "getRoleEnvironmentData" does not really load configuration data. Anyway, I keep the code there. It is relative old code now.
4. We have existing UT there to exercise the code. 
