### PR TITLE
allow CI failure for node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 matrix:
   allow_failures:
     - node_js: "0.11"
+    - node_js: "0.8"
 
 # setup links to submodules
 before_install:


### PR DESCRIPTION
The node 0.8 could not handle "npm update -g npm" well. Chatted with colleagues, we move it to the "allow failures" section
