### PR TITLE
Update README.md

### DIFF
--- a/lib/services/management/README.md
+++ b/lib/services/management/README.md
@@ -35,7 +35,7 @@ var fs         = require('fs'),
 
 var managementClient = management.createManagementClient(management.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
-  pem: fs.readFileSync('<your pem file>')
+  pem: fs.readFileSync('<your pem file>').toString()
 }));
 ```
 


### PR DESCRIPTION
Syntax error in 

pem: fs.readFileSync('<your pem file>').The SDK is not converting the node buffer to a string , bug on this is reported here https://github.com/Azure/azure-sdk-for-node/issues/1137 

Correct Syntax is 

 pem: fs.readFileSync('<your pem file>').toString()
