### PR TITLE
fixes example for createCertificateCloudCredentials

### DIFF
--- a/lib/services/management/README.md
+++ b/lib/services/management/README.md
@@ -35,7 +35,7 @@ var fs         = require('fs'),
 
 var managementClient = management.createManagementClient(management.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
-  pem: fs.readFileSync('<your pem file>')
+  pem: fs.readFileSync('<your pem file>', 'utf8')
 }));
 ```
 


### PR DESCRIPTION
If you don't specify an encoding, readFileSync returns a Buffer, and createCertificateCloudCredentials fails.
