### PR TITLE
Specify pem file encoding

### DIFF
--- a/lib/services/computeManagement/README.md
+++ b/lib/services/computeManagement/README.md
@@ -38,7 +38,7 @@ var fs                = require('fs'),
 
 var computeManagementClient = computeManagement.createComputeManagementClient(computeManagement.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
-  pem: fs.readFileSync('<your pem file>')
+  pem: fs.readFileSync('<your pem file>', 'utf-8')
 }));
 ``` 
 


### PR DESCRIPTION
Without the encoding specified, the pem file is read in as a buffer instead of a string.
This would then fail the argument validation requirement for credentials.pem since it wanted a string and got a buffer.
Without the encoding I was unable to run this example.
With the encoding specified, I am able to run the example.