### PR TITLE
Fix name of virtual machine images

### DIFF
--- a/lib/services/computeManagement/README.md
+++ b/lib/services/computeManagement/README.md
@@ -52,7 +52,7 @@ var storageAccountName = "storage01";
 var diskContainerName = "vhds";
 
 // List all the virtual machine images you can use.
-computeManagementClient.virtualMachineImages.list(function (err, result) {
+computeManagementClient.virtualMachineVMImages.list(function (err, result) {
   if (err) {
     console.error(err);
   } else {


### PR DESCRIPTION
Looks like `virtualMachineImages` no longer exists and has been broken up into multiple objects.
`virtualMachineVMImages` gave me the info I needed to list all images, not sure if `virtualMachineOSImages` was needed instead though.