### PR TITLE
this api returns a 200 when you change user credentials from the CLI. 

### DIFF
--- a/lib/services/webSiteManagement/lib/webSiteManagementClient.js
+++ b/lib/services/webSiteManagement/lib/webSiteManagementClient.js
@@ -7982,7 +7982,7 @@ var WebSpaceOperations = ( /** @lends WebSpaceOperations */ function() {
         return callback(err);
       }
       var statusCode = response.statusCode;
-      if (statusCode !== 201) {
+      if (statusCode !== 200 && statusCode !== 201) {
         var error = new Error(body);
         error.statusCode = response.statusCode;
         return callback(error);
@@ -7991,7 +7991,7 @@ var WebSpaceOperations = ( /** @lends WebSpaceOperations */ function() {
       // Create Result
       var result = null;
       // Deserialize Response
-      if (statusCode === 201) {
+      if (statusCode === 200 || statusCode === 201) {
         var responseContent = body;
         result = {};
         var options = {};


### PR DESCRIPTION
I don't have an account to test when you set credentials for the first time but I suspect that may return a 201. Either case this fixes an issue in the cli when trying to set user credentials and getting an error object back with a 200 http status.

Example:
```
$ azure site deployment user set
info:    Executing command site deployment user set
Git username: sedouard
Git password: **********
Confirm password: **********
+ Setting user credentials                                                     
error:   Error
info:    Error information has been recorded to /Users/user/.azure/azure.err
error:   site deployment user set command failed
$ cat /Users/user/.azure/azure.err
Mon Feb 23 2015 15:36:22 GMT-0800 (PST):
{ [Error]
  stack: [Getter/Setter],
  statusCode: 200,
  __frame: 
   { name: '__5',
     line: 212,
     file: '/usr/local/lib/node_modules/azure-cli/lib/commands/asm/site.deployment._js',
     prev: undefined,
     active: false,
     offset: 7,
     col: 8 },
  rawStack: [Getter] }
Error
    at /usr/local/lib/node_modules/azure-cli/node_modules/azure/node_modules/azure-mgmt-website/lib/webSiteManagementClient.js:7986:21
    at handleRedirect (/usr/local/lib/node_modules/azure-cli/lib/util/utils.js:145:9)
    at /usr/local/lib/node_modules/azure-cli/lib/util/logging.js:244:7
    at handleRedirect (/usr/local/lib/node_modules/azure-cli/node_modules/azure-common/lib/services/filters/redirectfilter.js:36:9)
    at /usr/local/lib/node_modules/azure-cli/node_modules/azure-common/lib/services/filters/errorhandlingfilter.js:49:7
    at Request._callback (/usr/local/lib/node_modules/azure-cli/node_modules/azure-common/lib/http/request-pipeline.js:109:14)
    at Request.self.callback (/usr/local/lib/node_modules/azure-cli/node_modules/request/request.js:129:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/lib/node_modules/azure-cli/node_modules/request/request.js:873:14)
    at Request.emit (events.js:117:20)
    at __5 (/usr/local/lib/node_modules/azure-cli/lib/commands/asm/site.deployment._js:219:8)
