### PR TITLE
fix jshint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "mocha": "1.16.0",
-    "jshint": ">= 2.1.4",
+    "jshint": "2.6.3",
     "sinon": "*",
     "should": "1.2.x",
     "nock": "0.30.1",


### PR DESCRIPTION
It appears people have different versions of jshint which all match our old range, but some errors are only reported from a specific version, this causes confusion.
 