### PR TITLE
npm test fails after cloning and running npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install azure
 
 ### Usage
 
-## Storage 
+## Storage
 
 For using Storage Blobs, Tables, Files, and Queues visit the Microsoft Azure Storage SDK for Node.js [ReadMe](https://github.com/Azure/azure-storage-node/blob/master/README.md) file.
 
@@ -305,3 +305,21 @@ azure.RoleEnvironment.getRoles(function(error, roles) {
 
 * If you would like to become an active contributor to this project please follow the instructions provided in [Microsoft Azure Projects Contribution Guidelines](http://azure.github.com/guidelines.html).
 * If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-sdk-for-node/issues) section of the project.
+
+## Getting Started Developing
+What to get started hacking on the code, super! Follow the following instructions to get up and running. These
+instructions expect you have Git and a supported version of Node installed.
+
+1. Fork it
+2. Git Clone your fork (`git clone {your repo}`)
+3. Move into sdk directory (`cd azure-sdk-for-node`)
+4. Install all dependencies (`npm install`)
+5. Run the tests (`npm test`). You should see all tests passing.
+
+## Contributing Code to the Project
+You found something you'd like to change, great! Please submit a pull request and we'll do our best to work with you to
+get your code included into the project.
+
+1. Commit your changes (`git commit -am 'Add some feature'`)
+2. Push to the branch (`git push origin my-new-feature`)
+3. Create new Pull Request

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "nock": "0.30.1",
     "grunt": "~0.4.2",
     "grunt-jsdoc": "~0.5.1",
-    "grunt-devserver": "~0.4.1"
+    "grunt-devserver": "~0.4.1",
+    "azure-storage-legacy": "0.9.14",
+    "xmlbuilder": "0.4.3"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {


### PR DESCRIPTION
As a developer I expect to be able to clone the repo, do an `npm install` and then run `npm test` to see all tests passing. This is not currently the case. The travis CI script pulls down the CLI and the node project, then does some npm linking, which leads to different results than just pulling down the project and running the tests. This will allow the tests to pass when the project is cloned, installed and tested.

Post this PR, there should be though given to how travis executes. There certainly is value in testing the CLI project with the SDK, but we may want to build the links after the SDK has run through it's own test suite.