### PR TITLE
add a namespace attribute to the root node for #1416

### DIFF
--- a/lib/services/sqlManagement/lib/sqlManagementClient.js
+++ b/lib/services/sqlManagement/lib/sqlManagementClient.js
@@ -909,6 +909,10 @@ var DacOperations = ( /** @lends DacOperations */ function() {
       var importInputElement = js2xml.createElement('ImportInput', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
       js2xml.addChildElement(requestDoc, importInputElement);
       
+      var nsAttribute = js2xml.createAttribute('xmlns:i', 'http://www.w3.org/2001/XMLSchema-instance');
+      js2xml.setAttributeValue(nsAttribute, 'http://www.w3.org/2001/XMLSchema-instance');
+      js2xml.addAttribute(importInputElement, nsAttribute);
+
       if (parameters.azureEdition !== null && parameters.azureEdition !== undefined) {
         var azureEditionElement = js2xml.createElement('AzureEdition', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
         js2xml.setElementValue(azureEditionElement, parameters.azureEdition);

--- a/lib/services/sqlManagement/lib/sqlManagementClient.js
+++ b/lib/services/sqlManagement/lib/sqlManagementClient.js
@@ -288,12 +288,16 @@ var DacOperations = ( /** @lends DacOperations */ function() {
     if (parameters !== null && parameters !== undefined) {
       var exportInputElement = js2xml.createElement('ExportInput', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
       js2xml.addChildElement(requestDoc, exportInputElement);
+
+      var nsAttribute = js2xml.createAttribute('xmlns:i', 'http://www.w3.org/2001/XMLSchema-instance');
+      js2xml.setAttributeValue(nsAttribute, 'http://www.w3.org/2001/XMLSchema-instance');
+      js2xml.addAttribute(exportInputElement, nsAttribute);
       
       if (parameters.blobCredentials !== null && parameters.blobCredentials !== undefined) {
         var blobCredentialsElement = js2xml.createElement('BlobCredentials', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
         js2xml.addChildElement(exportInputElement, blobCredentialsElement);
         
-        var typeAttribute = js2xml.createAttribute('type', 'http://www.w3.org/2001/XMLSchema-instance');
+        var typeAttribute = js2xml.createAttribute('i:type', 'http://www.w3.org/2001/XMLSchema-instance');
         js2xml.setAttributeValue(typeAttribute, 'BlobStorageAccessKeyCredentials');
         js2xml.addAttribute(blobCredentialsElement, typeAttribute);
         
@@ -923,7 +927,7 @@ var DacOperations = ( /** @lends DacOperations */ function() {
         var blobCredentialsElement = js2xml.createElement('BlobCredentials', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
         js2xml.addChildElement(importInputElement, blobCredentialsElement);
         
-        var typeAttribute = js2xml.createAttribute('type', 'http://www.w3.org/2001/XMLSchema-instance');
+        var typeAttribute = js2xml.createAttribute('i:type', 'http://www.w3.org/2001/XMLSchema-instance');
         js2xml.setAttributeValue(typeAttribute, 'BlobStorageAccessKeyCredentials');
         js2xml.addAttribute(blobCredentialsElement, typeAttribute);
         


### PR DESCRIPTION
A missing namespace in the XML request makes the `sqlmgmt.dac.importMethod()` to fail. see #1416

This PR naively adds the namespace as an attribute of the root node.