### PR TITLE
Fixed parameter ordering for createSchedulerClient

### DIFF
--- a/lib/services/scheduler/lib/scheduler.js
+++ b/lib/services/scheduler/lib/scheduler.js
@@ -24,18 +24,17 @@ exports.SchedulerClient = SchedulerClient;
 *
 * NOTE: These APIs are still in development and should not be used.
 *
+* @param {string} cloudServiceName
+* @param {string} jobCollectionName
 * @param {string} [credentials.subscriptionId]      The subscription identifier.
 * @param {string} [credentials.cert]                The cert value.
 * @param {string} [credentials.key]                 The key value.
-* @param {string} cloudServiceName
-*
-* @param {string} jobCollectionName
 * @param {string} [baseUri]                         The base uri.
 * @param {array}  [filters]                         Optional array of service filters
 * @return {SchedulerClient}                         A new SchedulerClient object.
 */
-exports.createSchedulerClient = function (credentials, cloudServiceName, jobCollectionName, baseUri, filters) {
-  return new exports.SchedulerClient.SchedulerClient(credentials, cloudServiceName, jobCollectionName, baseUri, filters);
+exports.createSchedulerClient = function (cloudServiceName, jobCollectionName, credentials, baseUri, filters) {
+  return new exports.SchedulerClient.SchedulerClient(cloudServiceName, jobCollectionName, credentials, baseUri, filters);
 };
 
 var common = require('azure-common');
@@ -44,10 +43,10 @@ var common = require('azure-common');
 * Creates a new CertificateCloudCredentials object.
 * Either a pair of cert / key values need to be pass or a pem file location.
 *
-* @param {string} credentials.subscription  The subscription identifier.
-* @param {string} [credentials.cert]        The certificate.
-* @param {string} [credentials.key]         The certificate key.
-* @param {string} [credentials.pem]         The PEM file content.
+* @param {string} credentials.subscriptionId  The subscription identifier.
+* @param {string} [credentials.cert]          The certificate.
+* @param {string} [credentials.key]           The certificate key.
+* @param {string} [credentials.pem]           The PEM file content.
 * @return {CertificateCloudCredentials}
 */
 exports.createCertificateCloudCredentials = function (credentials) {


### PR DESCRIPTION
cloudServiceName should be the first parameter and credentials should be the third.