### PR TITLE
Update validator module to fix security issue

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -37,7 +37,7 @@
     "underscore": "1.4.x",
     "tunnel": "~0.0.2",
     "request": "2.45.0",
-    "validator": "~3.1.0",
+    "validator": "~3.22.2",
     "envconf": "~0.0.4",
     "duplexer": "~0.1.1",
     "through": "~2.3.4"


### PR DESCRIPTION
Update validator module to version 3.22.2 (same version as in azure-storage module) to fix security vulnerability (https://github.com/Azure/azure-sdk-for-node/issues/1425).

All unit tests seems good.