### PR TITLE
Autodiscover services in setup.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     }
   ],
   "dependencies": {
-    "azure-common": "0.9.12", 
-    "azure-asm-compute": "0.10.0", 
+    "azure-common": "0.9.12",
+    "azure-asm-compute": "0.10.0",
     "azure-asm-hdinsight": "0.10.0",
     "azure-asm-mgmt": "0.10.0",
     "azure-monitoring": "0.10.0",
@@ -78,7 +78,8 @@
     "grunt-jsdoc": "~0.5.1",
     "grunt-devserver": "~0.4.1",
     "azure-storage-legacy": "0.9.14",
-    "xmlbuilder": "0.4.3"
+    "xmlbuilder": "0.4.3",
+    "readable-stream": "~1.0.0"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {

--- a/scripts/each-service.js
+++ b/scripts/each-service.js
@@ -4,7 +4,6 @@
 var fs = require('fs');
 var path = require('path');
 var stream = require('readable-stream');
-var through = require('through');
 var util = require('util');
 
 var sdkRoot = path.join(__dirname, '..');

--- a/scripts/each-service.js
+++ b/scripts/each-service.js
@@ -1,0 +1,94 @@
+// Helper script that can read the set of services included
+// in the azure SDK dynamically.
+
+var fs = require('fs');
+var path = require('path');
+var stream = require('readable-stream');
+var through = require('through');
+var util = require('util');
+
+var sdkRoot = path.join(__dirname, '..');
+var servicesRoot = path.join(sdkRoot, 'lib/services');
+
+//
+// Custom streams used in our implementation below.
+//
+// First is a readable stream that just passes through strings
+// in object mode.
+//
+
+function ServiceStream() {
+  stream.Readable.call(this, { objectMode: true });
+  this.readAll = false;
+}
+
+util.inherits(ServiceStream, stream.Readable);
+
+ServiceStream.prototype._read = function () {
+  var self = this;
+  if (!self.readAll) {
+    self.readAll = true;
+    fs.readdir(servicesRoot, function (err, files) {
+      if (err) {
+        return self.emit('error', err);
+      }
+
+      self.push(path.join(sdkRoot, 'lib/common'));
+      files.map(function (f) { return path.join(servicesRoot, f); })
+        .forEach(self.push.bind(self));
+      self.push(null);
+    });
+  }
+};
+
+//
+// Transform stream that reads the package.json in the
+// directory given.
+//
+function ReadPackageJsonStream() {
+  stream.Transform.call(this, {objectMode: true});
+}
+
+util.inherits(ReadPackageJsonStream, stream.Transform);
+
+ReadPackageJsonStream.prototype._transform = function(servicepath, encoding, callback) {
+  var self = this;
+  packagejsonpath = path.join(servicepath, 'package.json');
+  fs.exists(packagejsonpath, function (exists) {
+    if (exists) {
+      fs.readFile(packagejsonpath, {encoding: 'utf8'}, function (err, text) {
+        if (err) { return callback(err); }
+        var json = JSON.parse(text.trim());
+        self.push({path: servicepath, packageJson: json});
+        callback();
+      });
+    } else {
+      callback();
+    }
+  });
+};
+
+function forEachService(iterator, done) {
+  var s = new ServiceStream().pipe(new ReadPackageJsonStream());
+  function processNext(serviceData) {
+    if (serviceData != null) {
+      iterator(serviceData, function (err) {
+        if (err) { return done(err); }
+        processNext(s.read());
+      });
+    } else {
+      s.once('readable', function () {
+        processNext(s.read());
+      });
+    }
+  }
+
+  s.on('error', done);
+  s.on('end', function () {
+    done();
+  });
+
+  processNext(null);
+}
+
+module.exports = forEachService;

--- a/scripts/each-service.js
+++ b/scripts/each-service.js
@@ -52,7 +52,8 @@ ReadPackageJsonStream.prototype._transform = function(servicepath, encoding, cal
   packagejsonpath = path.join(servicepath, 'package.json');
   fs.exists(packagejsonpath, function (exists) {
     if (exists) {
-      fs.readFile(packagejsonpath, {encoding: 'utf8'}, function (err, text) {
+      fs.readFile(packagejsonpath, function (err, buffer) {
+        var text = buffer.toString();
         if (err) { return callback(err); }
         var json = JSON.parse(text.trim());
         self.push({path: servicepath, packageJson: json});
@@ -88,13 +89,3 @@ function forEachService(iterator, done) {
 }
 
 module.exports = forEachService;
-module.exports.test = function () {
-  forEachService(function (service, next) {
-    console.log(service.packageJson.name, ":", service.path);
-    next();
-  },
-  function (err) {
-    if (err) { console.log('Failed with error', err); }
-    else { console.log('done'); }
-  });
-};

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,94 +1,24 @@
+var path = require('path');
+var eachService = require('./each-service');
 var executeCmds = require('./executeCmds.js');
-var cmds = [
-  { cmd: 'npm install', path: 'lib/common/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/legacyStorage' },
-  { cmd: 'npm install', path: 'lib/services/legacyStorage' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/computeManagement/' },
-  { cmd: 'npm install', path: 'lib/services/computeManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/computeManagement2/' },
-  { cmd: 'npm install', path: 'lib/services/computeManagement2/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/dnsManagement/' },
-  { cmd: 'npm install', path: 'lib/services/dnsManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/trafficManagerManagement/' },
-  { cmd: 'npm install', path: 'lib/services/trafficManagerManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/management/' },
-  { cmd: 'npm install', path: 'lib/services/management/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/networkManagement/' },
-  { cmd: 'npm install', path: 'lib/services/networkManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/networkManagement2/' },
-  { cmd: 'npm install', path: 'lib/services/networkManagement2/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/monitoring/' },
-  { cmd: 'npm install', path: 'lib/services/monitoring/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/scheduler/' },
-  { cmd: 'npm install', path: 'lib/services/scheduler/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/schedulerManagement/' },
-  { cmd: 'npm install', path: 'lib/services/schedulerManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/serviceBusManagement/' },
-  { cmd: 'npm install', path: 'lib/services/serviceBusManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/sqlManagement/' },
-  { cmd: 'npm install', path: 'lib/services/sqlManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/storageManagement/' },
-  { cmd: 'npm install', path: 'lib/services/storageManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/storageManagement2/' },
-  { cmd: 'npm install', path: 'lib/services/storageManagement2/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/storeManagement/' },
-  { cmd: 'npm install', path: 'lib/services/storeManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/subscriptionManagement/' },
-  { cmd: 'npm install', path: 'lib/services/subscriptionManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/webSiteManagement/' },
-  { cmd: 'npm install', path: 'lib/services/webSiteManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/resourceManagement/' },
-  { cmd: 'npm install', path: 'lib/services/resourceManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/gallery/' },
-  { cmd: 'npm install', path: 'lib/services/gallery/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/authorizationManagement/' },
-  { cmd: 'npm install', path: 'lib/services/authorizationManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/extra/' },
-  { cmd: 'npm install', path: 'lib/services/extra/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/webSiteManagement2/' },
-  { cmd: 'npm install', path: 'lib/services/webSiteManagement2/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/hdinsight/' },
-  { cmd: 'npm install', path: 'lib/services/hdinsight/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/serviceBus/' },
-  { cmd: 'npm install', path: 'lib/services/serviceBus/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/insights/' },
-  { cmd: 'npm install', path: 'lib/services/insights/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/keyVault/' },
-  { cmd: 'npm install', path: 'lib/services/keyVault/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/keyVaultManagement/' },
-  { cmd: 'npm install', path: 'lib/services/keyVaultManagement/' },
-  { cmd: 'npm link ../../common/', path: 'lib/services/apiAppManagement/' },
-  { cmd: 'npm install', path: 'lib/services/apiAppManagement/' },
-  { cmd: 'npm link lib/common/' },
-  { cmd: 'npm link lib/services/legacyStorage' },
-  { cmd: 'npm link lib/services/computeManagement/' },
-  { cmd: 'npm link lib/services/computeManagement2/' },
-  { cmd: 'npm link lib/services/dnsManagement/' },
-  { cmd: 'npm link lib/services/trafficManagerManagement/' },
-  { cmd: 'npm link lib/services/management/' },
-  { cmd: 'npm link lib/services/networkManagement/' },
-  { cmd: 'npm link lib/services/networkManagement2/' },
-  { cmd: 'npm link lib/services/monitoring/' },
-  { cmd: 'npm link lib/services/scheduler/' },
-  { cmd: 'npm link lib/services/schedulerManagement/' },
-  { cmd: 'npm link lib/services/serviceBusManagement/' },
-  { cmd: 'npm link lib/services/sqlManagement/' },
-  { cmd: 'npm link lib/services/storageManagement/' },
-  { cmd: 'npm link lib/services/storageManagement2/' },
-  { cmd: 'npm link lib/services/storeManagement/' },
-  { cmd: 'npm link lib/services/subscriptionManagement/' },
-  { cmd: 'npm link lib/services/webSiteManagement/' },
-  { cmd: 'npm link lib/services/resourceManagement/' },
-  { cmd: 'npm link lib/services/gallery/' },
-  { cmd: 'npm link lib/services/webSiteManagement2/' },
-  { cmd: 'npm link lib/services/hdinsight/' },
-  { cmd: 'npm link lib/services/serviceBus/' },
-  { cmd: 'npm link lib/services/keyVault/' },
-  { cmd: 'npm link lib/services/keyVaultManagement/' },
-  { cmd: 'npm link lib/services/insights/' },
-  { cmd: 'npm link lib/services/authorizationManagement/' },
-  { cmd: 'npm link lib/services/apiAppManagement/' },
-  { cmd: 'npm link lib/services/extra/' }
-];
 
-executeCmds.execute(cmds);
+var cmds = [];
+var sdkRootPath = path.join(__dirname, '..');
+
+eachService(function(serviceData, next) {
+    var relpath = path.relative(sdkRootPath, serviceData.path);
+    if(serviceData.packageJson.name === 'azure-common') {
+      cmds.push({cmd: 'npm install', path: relpath });
+      cmds.push({ cmd: 'npm link ' + relpath });
+    } else {
+      cmds.push({ cmd: 'npm link ../../common/', path: relpath });
+      cmds.push({ cmd: 'npm install', path: relpath });
+      cmds.push({ cmd: 'npm link ' + relpath });
+    }
+    next();
+  },
+  function () {
+    cmds.forEach(function (cmd) { console.log(cmd); });
+    executeCmds.execute(cmds);
+  }
+);

--- a/scripts/teardown.js
+++ b/scripts/teardown.js
@@ -1,0 +1,29 @@
+//
+// Helper script that tears down the symlinks created by the
+// setup.js script in this folder.
+//
+
+var npm = require('npm');
+var eachService = require('./each-service');
+
+npm.load({global: true}, function (err, npm) {
+  if (err) {
+    console.log('Unable to initialize npm:', err);
+    return;
+  }
+
+  console.log('npm is running against', npm.dir);
+  console.log('Uninstalling azure modules');
+
+  eachService(function (serviceData, next) {
+    npm.commands.uninstall(serviceData.packageJson.name, function (err) {
+      if (err) {
+        console.log('Package', serviceData.packageJson.name, 'failed to uninstall, err =', err);
+      }
+      next(err);
+    });
+  },
+  function (err) {
+    console.log('Package uninstall complete');
+  });
+});


### PR DESCRIPTION
I've found maintaining setup.js over time to be a real PITA as we add services, and undoing what it does to my machine is equally annoying. This PR includes suggested changes to the setup.js script so that it will automatically discover any directory under lib/services, no more needed to manually update that file.

In addition, it also adds a teardown.js to remove all the modules from the global space, making it a lot easier to undo the damage caused by setup.js. :-)
