### PR TITLE
update azure-storage module to fix security issues

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -37,7 +37,7 @@
     "underscore": "1.4.x",
     "tunnel": "~0.0.2",
     "request": "2.45.0",
-    "validator": "~3.1.0",
+    "validator": "~3.22.2",
     "envconf": "~0.0.4",
     "duplexer": "~0.1.1",
     "through": "~2.3.4"


### PR DESCRIPTION
Update azure-storage to version 0.4.5 to fix the following security issues:
- https://github.com/Azure/azure-storage-node/issues/61
- https://github.com/Azure/azure-storage-node/pull/65

All tests seems good with this new version.