### PR TITLE
Rev'd the version of the commerce package

### DIFF
--- a/lib/services/commerce/package.json
+++ b/lib/services/commerce/package.json
@@ -4,7 +4,7 @@
   "contributors": [
     "Commerce Platform Usage Team <cpusage@microsoft.com>"
   ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Microsoft Azure Commerce Usage Aggregates Management Client Library for Node",
   "tags": [
     "azure",


### PR DESCRIPTION
Received the following during the build:
npm ERR! "You cannot publish over the previously published version 0.1.0." : azure-arm-commerce
npm ERR! 

this change will fix it