### PR TITLE
Update events client to use api version 2014-04-01

### DIFF
--- a/lib/services/monitoring/lib/eventsClient.js
+++ b/lib/services/monitoring/lib/eventsClient.js
@@ -60,7 +60,7 @@ var EventsClient = ( /** @lends EventsClient */ function() {
       this.baseUri = 'https://management.core.windows.net';
     }
     if (this.apiVersion === null || this.apiVersion === undefined) {
-      this.apiVersion = '2014-04';
+      this.apiVersion = '2014-04-01';
     }
     if (this.longRunningOperationInitialTimeout === null || this.longRunningOperationInitialTimeout === undefined) {
       this.longRunningOperationInitialTimeout = -1;
@@ -132,7 +132,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {
       url2 = url2 + '&eventTimestamp le \'' + encodeURIComponent(parameters.endTime.toISOString()) + '\' and ';
@@ -508,7 +508,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=correlationId eq \'' + encodeURIComponent(parameters.correlationId.trim()) + '\' and ';
     url2 = url2 + '&eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {
@@ -885,7 +885,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=eventSource eq \'' + encodeURIComponent(parameters.eventSource.trim()) + '\' and ';
     url2 = url2 + '&eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {
@@ -1262,7 +1262,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=resourceUri eq \'' + encodeURIComponent(parameters.resourceUri.trim()) + '\' and ';
     url2 = url2 + '&eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {
@@ -1639,7 +1639,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=resourceGroupName eq \'' + encodeURIComponent(parameters.resourceGroupName.trim()) + '\' and ';
     url2 = url2 + '&eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {
@@ -2016,7 +2016,7 @@ var EventDataOperations = ( /** @lends EventDataOperations */ function() {
     
     // Construct URL
     var url2 = '/subscriptions/' + (this.client.credentials.subscriptionId ? this.client.credentials.subscriptionId.trim() : '') + '/providers/microsoft.insights/eventtypes/management/values?';
-    url2 = url2 + 'api-version=2014-04';
+    url2 = url2 + 'api-version=2014-04-01';
     url2 = url2 + '&$filter=resourceProvider eq \'' + encodeURIComponent(parameters.resourceProvider.trim()) + '\' and ';
     url2 = url2 + '&eventTimestamp ge \'' + encodeURIComponent(parameters.startTime.toISOString()) + '\' and ';
     if (parameters.endTime) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "azure-asm-compute": "0.10.0",
     "azure-asm-hdinsight": "0.10.0",
     "azure-asm-mgmt": "0.10.0",
-    "azure-monitoring": "0.10.0",
+    "azure-monitoring": "0.10.1",
     "azure-asm-network": "0.10.0",
     "azure-scheduler": "0.10.0",
     "azure-asm-scheduler": "0.10.0",


### PR DESCRIPTION
Update events client to use api version 2014-04-01. Events stopped supported YYYY-MM version recently, and this is breaking group log CLI commands