### PR TITLE
Fix a typo in website management README.md

### DIFF
--- a/lib/services/webSiteManagement/README.md
+++ b/lib/services/webSiteManagement/README.md
@@ -32,7 +32,7 @@ This library support management certificate authentication. To authenticate the 
 var fs                = require('fs'),
     webSiteManagement = require('azure-asm-website');
 
-var webSiteManagementClient = webSiteManagement.createWebsiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
+var webSiteManagementClient = webSiteManagement.createWebSiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
   pem: fs.readFileSync('<your pem file>')
 }));

--- a/lib/services/webSiteManagement2/README.md
+++ b/lib/services/webSiteManagement2/README.md
@@ -26,7 +26,7 @@ npm install azure-arm-website
 var fs                = require('fs'),
     webSiteManagement = require('azure-arm-website');
 
-var webSiteManagementClient = webSiteManagement.createWebsiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
+var webSiteManagementClient = webSiteManagement.createWebSiteManagementClient(webSiteManagement.createCertificateCloudCredentials({
   subscriptionId: '<your subscription id>',
   pem: fs.readFileSync('<your pem file>')
 }));


### PR DESCRIPTION
When you copy and paste the code sample from the README.md file, it doesn't work without this fix.

`createWebsiteManagementClient` -> `createWebSiteManagementClient`