### PR TITLE
Added BlobService.statusOfCopyBlob, method to get the status of a blob copy operation

### DIFF
--- a/lib/services/legacyStorage/lib/blob/blobservice.js
+++ b/lib/services/legacyStorage/lib/blob/blobservice.js
@@ -1861,6 +1861,66 @@ BlobService.prototype.abortCopyBlob = function (container, blob, copyId, options
 };
 
 /**
+* Gets the status of the copyBlob operation
+*
+* @this {BlobService}
+* @param {string}             targetContainer                             The target container name.
+* @param {string}             targetBlob                                  The target blob name.
+* @param {object}             [options]                                   The blobs and request options.
+* @param {object}             [options.metadata]                          The target blob metadata key/value pairs.
+* @param {string}             [options.leaseId]                           The target blob lease identifier.
+* @param {object}             [options.accessConditions]                  The access conditions. See http://msdn.microsoft.com/en-us/library/dd179371.aspx for more information.
+* @param {int}                [options.timeoutIntervalInMs]               The timeout interval, in milliseconds, to use for the request.
+* @param {Function(error, blob, response)}  callback                      `error` will contain information
+*                                                                         if an error occurs; otherwise `blob` will contain
+*                                                                         the blob information.
+*                                                                         `response` will contain information related to this operation.
+*/
+BlobService.prototype.statusOfCopyBlob = function (targetContainer, targetBlob, optionsOrCallback, callback) {
+  var options;
+  azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { options = o; callback = c; });
+
+  validate.validateArgs('copyBlob', function (v) {
+    v.string(targetContainer, 'targetContainer');
+    v.string(targetBlob, 'targetBlob');
+    v.containerNameIsValid(targetContainer);
+    v.blobNameIsValid(targetContainer, targetBlob);
+    v.callback(callback);
+  });
+
+  var targetResourceName = createResourceName(targetContainer, targetBlob);
+
+  var webResource = WebResource.head(targetResourceName)
+    .withProperty(BlobConstants.ResourceTypeProperty, BlobConstants.ResourceTypes.BLOB)
+    .withProperty(BlobConstants.SharedAccessPermissionProperty, BlobConstants.SharedAccessPermissions.WRITE);
+
+  if (options) {
+    webResource.withHeader(HeaderConstants.LEASE_ID_HEADER, options.leaseId);
+    webResource.addOptionalMetadataHeaders(options.metadata);
+  }
+
+  var processResponseCallback = function (responseObject, next) {
+    responseObject.blobResult = null;
+    if (!responseObject.error) {
+      responseObject.blobResult = new BlobResult(targetContainer, targetBlob);
+      responseObject.blobResult.getPropertiesFromHeaders(responseObject.response.headers);
+
+      if (options && options.metadata) {
+        responseObject.blobResult.metadata = options.metadata;
+      }
+    }
+
+    var finalCallback = function (returnObject) {
+      callback(returnObject.error, returnObject.blobResult, returnObject.response);
+    };
+
+    next(responseObject, finalCallback);
+  };
+
+  this.performRequest(webResource, null, options, processResponseCallback);
+};
+
+/**
 * Acquires a new lease on the blob.
 *
 * @this {BlobService}


### PR DESCRIPTION
The Node API is currently missing the method to get the status of Blob copying. This is troublesome especially when copying large blobs like VHD images (e.g. when transferring VMs from one subscription to another).

This commit fixes that. Programmed according to this reference: http://blog.elastacloud.com/2012/07/04/copying-azure-blobs-from-one-subscription-to-another-with-api-1-7-1/ and checked working.

There is also a test prepared for the method in the with-test branch, but I don't have the knowledge to emulate the Nock mockup at this time, so the test is failing.