### PR TITLE
Graph: Add the includeDirectoryObjectReferences flag to the GetObjectsByObjectIds call 

### DIFF
--- a/lib/services/extra/lib/graphRbacManagementClient.js
+++ b/lib/services/extra/lib/graphRbacManagementClient.js
@@ -2060,6 +2060,9 @@ var ObjectOperations = ( /** @lends ObjectOperations */ function() {
    * 
    * @param {array} [parameters.types] Requested object types
    * 
+   * @param {boolean} parameters.includeDirectoryObjectReferences If true, also
+   * searches for object ids in the partner tenant
+   * 
    * @param {function} callback
    * 
    * @returns {Stream} The response stream.
@@ -2071,6 +2074,9 @@ var ObjectOperations = ( /** @lends ObjectOperations */ function() {
     // Validate
     if (parameters === null || parameters === undefined) {
       return callback(new Error('parameters cannot be null.'));
+    }
+    if (parameters.includeDirectoryObjectReferences === null || parameters.includeDirectoryObjectReferences === undefined) {
+      return callback(new Error('parameters.includeDirectoryObjectReferences cannot be null.'));
     }
     
     // Tracing
@@ -2129,6 +2135,8 @@ var ObjectOperations = ( /** @lends ObjectOperations */ function() {
       }
       getObjectsParametersValue['types'] = typesArray;
     }
+    
+    getObjectsParametersValue['includeDirectoryObjectReferences'] = parameters.includeDirectoryObjectReferences;
     
     requestContent = JSON.stringify(requestDoc);
     httpRequest.body = requestContent;

--- a/lib/services/extra/package.json
+++ b/lib/services/extra/package.json
@@ -7,7 +7,7 @@
     "Tavares, Chris <ctavares@microsoft.com>",
     "Mkrtchyan, Hovsep <hovsepm@microsoft.com>"
   ],
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Microsoft Azure Client Library in node for miscellaneous items",
   "tags": [
     "azure",


### PR DESCRIPTION
This also searches for object ids in the partner tenant (artemis/CSP scenario)