### PR TITLE
Update the version of azure-common

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -11,7 +11,7 @@
     "Tavares, Chris <ctavares@microsoft.com>",
     "Kulshrestha, Ankur <ankurkul@microsoft.com>"
   ],
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Microsoft Azure Common Client Library for node",
   "tags": [
     "azure",


### PR DESCRIPTION
I made a change to Azure Common (to service.js) to enable passing in
options to service client construction. This is required for the new
packages that have been added for DataLake*