### PR TITLE
fixed missing dep for underscore in dnsManagement package

### DIFF
--- a/lib/services/dnsManagement/package.json
+++ b/lib/services/dnsManagement/package.json
@@ -31,7 +31,8 @@
     }
   ],
   "dependencies": {
-    "azure-common": "^0.9.13"
+    "azure-common": "^0.9.13",
+    "underscore": "^1.8.3"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {


### PR DESCRIPTION
When using the dnsManagement package in isolation, the package can fail because `underscore` is not defined in the package.json. I've added it in to the package.json so `npm install` will correctly place the modules