### PR TITLE
Add support for x509 pem files using `BEGIN/END PRIVATE KEY`

### DIFF
--- a/lib/common/lib/util/keyFiles.js
+++ b/lib/common/lib/util/keyFiles.js
@@ -1,24 +1,24 @@
-// 
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 /**
  * Functions to work with key and certificate files data.
  */
 
-var KEY_PATT = /(-+BEGIN RSA PRIVATE KEY-+)(\n\r?|\r\n?)([A-Za-z0-9\+\/\n\r]+\=*)(\n\r?|\r\n?)(-+END RSA PRIVATE KEY-+)/;
+var KEY_PATT = /(-+BEGIN RSA PRIVATE KEY-+|-+BEGIN PRIVATE KEY-+)(\n\r?|\r\n?)([A-Za-z0-9\+\/\n\r]+\=*)(\n\r?|\r\n?)(-+END RSA PRIVATE KEY-+|-+END PRIVATE KEY-+)/;
 var CERT_PATT = /(-+BEGIN CERTIFICATE-+)(\n\r?|\r\n?)([A-Za-z0-9\+\/\n\r]+\=*)(\n\r?|\r\n?)(-+END CERTIFICATE-+)/;
 
 exports.read = function read (data) {


### PR DESCRIPTION
Depending on the version of openssl used to generate the management certificates
the private key may take one of two forms:

PKCS1 (Old, Currently Supported by us):

    -----BEGIN RSA PRIVATE KEY-----
    BASE64 ENCODED DATA
    -----END RSA PRIVATE KEY-----

PKCS8 (New, Support added in this commit):

    -----BEGIN PRIVATE KEY-----
    BASE64 ENCODED DATA
    -----END PRIVATE KEY-----

This commit adds support for the PKCS8 format. Prior to this commit using the PKCS8
format as part of a .pem would result in authentication failure as the key
would be undefined.