### PR TITLE
One more round of doc changes for DataLake

### DIFF
--- a/lib/services/dataLake.Analytics/README.md
+++ b/lib/services/dataLake.Analytics/README.md
@@ -84,4 +84,4 @@ async.series([
 ## Related projects
 
 - [Microsoft Azure SDK for Node.js](https://github.com/azure/azure-sdk-for-node)
-- [Microsoft Azure SDK for Node.js - Key Vault Management](https://github.com/Azure/azure-sdk-for-node/tree/master/lib/services/keyVault)
+- [Microsoft Azure SDK for Node.js - Data Lake Store Management](https://github.com/Azure/azure-sdk-for-node/tree/master/lib/services/dataLake.Analytics)

--- a/lib/services/dataLake.Analytics/package.json
+++ b/lib/services/dataLake.Analytics/package.json
@@ -4,8 +4,8 @@
   "contributors": [
     "Goldsmith, Benjamin <begoldsm@microsoft.com>"
   ],
-  "version": "0.1.4",
-  "description": "Microsoft Azure Data Lake Analytics Compute Management Client Library for node",
+  "version": "0.1.5",
+  "description": "Microsoft Azure Data Lake Analytics Management Client Library for node",
   "tags": [
     "azure",
     "sdk"

--- a/lib/services/dataLake.Store/README.md
+++ b/lib/services/dataLake.Store/README.md
@@ -85,4 +85,4 @@ async.series([
 ## Related projects
 
 - [Microsoft Azure SDK for Node.js](https://github.com/azure/azure-sdk-for-node)
-- [Microsoft Azure SDK for Node.js - Key Vault Management](https://github.com/Azure/azure-sdk-for-node/tree/master/lib/services/keyVault)
+- [Microsoft Azure SDK for Node.js - Data Lake Analytics Management](https://github.com/Azure/azure-sdk-for-node/tree/master/lib/services/dataLake.Store)

--- a/lib/services/dataLake.Store/package.json
+++ b/lib/services/dataLake.Store/package.json
@@ -4,8 +4,8 @@
   "contributors": [
     "Goldsmith, Benjamin <begoldsm@microsoft.com>"
   ],
-  "version": "0.1.3",
-  "description": "Microsoft Azure DataLake Storage Management Client Library for node",
+  "version": "0.1.4",
+  "description": "Microsoft Azure Data Lake Store Management Client Library for node",
   "tags": [
     "azure",
     "sdk"


### PR DESCRIPTION
remove key vault as related
Change naming to adhere to our official naming
Rev versions.