### PR TITLE
:bug: Add missing TableUtilities export. Fixes #1507

### DIFF
--- a/lib/azure.js
+++ b/lib/azure.js
@@ -25,7 +25,7 @@ var storage = require('azure-storage');
 
 var TableService = storage.TableService;
 exports.TableService = TableService;
-
+exports.TableUtilities = storage.TableUtilities;
 exports.TableQuery = storage.TableQuery;
 
 /**


### PR DESCRIPTION
Hi,
This commit adds missing export for TableUtilities module
from azure-storage.
The existing documentation and source code from samples
do expect this module on azure instance without direct import or `azure-storage`:
```JavaScript
var entityGen = azure.TableUtilities.entityGenerator
```
Thanks!