### PR TITLE
:bug: Add TableBatch export to azure. Fixes #1590

### DIFF
--- a/lib/azure.js
+++ b/lib/azure.js
@@ -27,6 +27,7 @@ var TableService = storage.TableService;
 exports.TableService = TableService;
 
 exports.TableQuery = storage.TableQuery;
+exports.TableBatch = storage.TableBatch;
 
 /**
 * Creates a new {@link TableService} object.


### PR DESCRIPTION
This commit adds missing export for TableBatch module
to global azure module.
Without that export that is not possible to write:
var batch = new azure.TableBatch()
as envisioned in documentation on using azure module
Thanks!