### PR TITLE
Fix in customProperty processing: numeric strings are not considered …

### DIFF
--- a/lib/services/serviceBus/lib/models/queuemessageresult.js
+++ b/lib/services/serviceBus/lib/models/queuemessageresult.js
@@ -96,6 +96,10 @@ exports._propertyFromString = function (value) {
 };
 
 exports.isRFC1123 = function (value) {
-  var date = new Date(value);
-  return azureutil.stringIsDate(date);
+  if(isNaN(value)) {
+    var date = new Date(value);
+    return azureutil.stringIsDate(date);  
+  } else {
+    return false;
+  }  
 };


### PR DESCRIPTION
Proposed solution to issue #1690 .
Strings containing only numbers in the customProperties object of messages exchanged on Service Bus queues, are now not considered valid dates.