### PR TITLE
Updating Key Vault management API version in 2 more places

### DIFF
--- a/lib/services/keyVaultManagement/lib/keyVaultManagementClient.js
+++ b/lib/services/keyVaultManagement/lib/keyVaultManagementClient.js
@@ -179,7 +179,7 @@ var VaultOperations = ( /** @lends VaultOperations */ function() {
     url2 = url2 + '/vaults/';
     url2 = url2 + encodeURIComponent(vaultName);
     var queryParameters = [];
-    queryParameters.push('api-version=2014-12-19-PREVIEW');
+    queryParameters.push('api-version=2015-06-01');
     if (queryParameters.length > 0) {
       url2 = url2 + '?' + queryParameters.join('&');
     }
@@ -451,7 +451,7 @@ var VaultOperations = ( /** @lends VaultOperations */ function() {
     url2 = url2 + '/vaults/';
     url2 = url2 + encodeURIComponent(vaultName);
     var queryParameters = [];
-    queryParameters.push('api-version=2014-12-19-PREVIEW');
+    queryParameters.push('api-version=2015-06-01');
     if (queryParameters.length > 0) {
       url2 = url2 + '?' + queryParameters.join('&');
     }

--- a/lib/services/keyVaultManagement/package.json
+++ b/lib/services/keyVaultManagement/package.json
@@ -9,7 +9,7 @@
     "Zavery, Amar <amzavery@microsoft.com>",
     "Wang, Yugang <yugangw@microsoft.com>"
   ],
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Microsoft Azure Key Vault Client Library for node",
   "tags": [
     "azure",


### PR DESCRIPTION
I missed 2 places with the retired API version in the previous commit, adding them now.