### PR TITLE
ADLA Swagger update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ var mappings = {
   }
 };
 
-var defaultAutoRestVersion = '0.17.0-Nightly20160518';
+var defaultAutoRestVersion = '0.17.0-Nightly20160606';
 var usingAutoRestVersion;
 var specRoot = args['spec-root'] || "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master";
 var project = args['project'];

--- a/lib/services/dataLake.Analytics/lib/catalog/models/index.d.ts
+++ b/lib/services/dataLake.Analytics/lib/catalog/models/index.d.ts
@@ -440,18 +440,37 @@ export interface USqlView extends CatalogItem {
  * 
  * @member {string} [name] Gets or sets the name of the table partition.
  * 
+ * @member {object} [parentName] Gets or sets the Ddl object of the
+ * partition's parent.
+ * 
+ * @member {string} [parentName.firstPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.secondPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.thirdPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.server] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
  * @member {number} [indexId] Gets or sets the index ID for this partition.
  * 
  * @member {array} [label] Gets or sets the list of labels associated with
  * this partition.
+ * 
+ * @member {date} [createDate] Gets or sets the creation time of the partition
  * 
  */
 export interface USqlTablePartition extends CatalogItem {
     databaseName?: string;
     schemaName?: string;
     name?: string;
+    parentName?: DdlName;
     indexId?: number;
     label?: string[];
+    createDate?: Date;
 }
 
 /**

--- a/lib/services/dataLake.Analytics/lib/catalog/models/uSqlTablePartition.js
+++ b/lib/services/dataLake.Analytics/lib/catalog/models/uSqlTablePartition.js
@@ -26,10 +26,27 @@ var util = require('util');
  * 
  * @member {string} [name] Gets or sets the name of the table partition.
  * 
+ * @member {object} [parentName] Gets or sets the Ddl object of the
+ * partition's parent.
+ * 
+ * @member {string} [parentName.firstPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.secondPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.thirdPart] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
+ * @member {string} [parentName.server] Gets or sets the name of the table
+ * associated with this database and schema.
+ * 
  * @member {number} [indexId] Gets or sets the index ID for this partition.
  * 
  * @member {array} [label] Gets or sets the list of labels associated with
  * this partition.
+ * 
+ * @member {date} [createDate] Gets or sets the creation time of the partition
  * 
  */
 function USqlTablePartition() {
@@ -87,6 +104,14 @@ USqlTablePartition.prototype.mapper = function () {
             name: 'String'
           }
         },
+        parentName: {
+          required: false,
+          serializedName: 'parentName',
+          type: {
+            name: 'Composite',
+            className: 'DdlName'
+          }
+        },
         indexId: {
           required: false,
           serializedName: 'indexId',
@@ -106,6 +131,13 @@ USqlTablePartition.prototype.mapper = function () {
                   name: 'String'
                 }
             }
+          }
+        },
+        createDate: {
+          required: false,
+          serializedName: 'createDate',
+          type: {
+            name: 'DateTime'
           }
         }
       }

--- a/lib/services/dataLake.Analytics/lib/job/operations/job.js
+++ b/lib/services/dataLake.Analytics/lib/job/operations/job.js
@@ -102,7 +102,7 @@ Job.prototype.getStatistics = function (accountName, jobIdentity, options, callb
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
-  httpRequest.method = 'POST';
+  httpRequest.method = 'GET';
   httpRequest.headers = {};
   httpRequest.url = requestUrl;
   // Set Headers

--- a/lib/services/dataLake.Analytics/package.json
+++ b/lib/services/dataLake.Analytics/package.json
@@ -4,7 +4,7 @@
   "contributors": [
     "Goldsmith, Benjamin <begoldsm@microsoft.com>"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Microsoft Azure Data Lake Analytics Management Client Library for node",
   "tags": [
     "azure",


### PR DESCRIPTION
This is an update based on the latest swagger:
Switch GetStatistics from POST to GET
Add two new properties to USqlTablePartition: ParentName and CreateDate.