### PR TITLE
Update the dependency package 'request' to version 2.69.0 to address the security vulunerablities found by NSP check

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -37,7 +37,7 @@
     "dateformat": "1.0.2-1.2.3",
     "underscore": "1.4.x",
     "tunnel": "~0.0.2",
-    "request": "2.45.0",
+    "request": "~2.69.0",
     "validator": "~3.22.2",
     "envconf": "~0.0.4",
     "duplexer": "~0.1.1",


### PR DESCRIPTION
Regular Expression Denial of Service

azure-common@0.9.16 > request@2.45.0 > hawk@1.1.1