### PR TITLE
fixed bug where null options object prevents defaults from being set

### DIFF
--- a/lib/common/lib/services/serviceclient.js
+++ b/lib/common/lib/services/serviceclient.js
@@ -396,15 +396,14 @@ ServiceClient.prototype._buildRequestOptions = function (webResource, body, opti
         ProxyFilter.setAgent(requestOptions, self.proxy);
       }
 
-      if(options) {
-        //set encoding of response data. If set to null, the body is returned as a Buffer
-        requestOptions.encoding = options.responseEncoding;
-        //set client request time out
-        if(options.clientRequestTimeout && options.clientRequestTimeout > 0) {
-          requestOptions.timeout = options.clientRequestTimeout;
-        } else {
-          requestOptions.timeout = Constants.DEFAULT_CLIENT_REQUEST_TIMEOUT;
-        }
+      options = options || {};
+      //set encoding of response data. If set to null, the body is returned as a Buffer
+      requestOptions.encoding = options.responseEncoding;
+      //set client request time out
+      if(options.clientRequestTimeout && options.clientRequestTimeout > 0) {
+        requestOptions.timeout = options.clientRequestTimeout;
+      } else {
+        requestOptions.timeout = Constants.DEFAULT_CLIENT_REQUEST_TIMEOUT;
       }
     }
 


### PR DESCRIPTION
When `options` is null, then the setting for `DEFAULT_CLIENT_REQUEST_TIMEOUT` is not correctly applied (so requests will _never_ timeout).

If `options` is null, set it to an empty object.