### PR TITLE
add storage profile with new hd insight cluster

### DIFF
--- a/lib/services/HDInsight2/lib/hDInsightManagementClient.js
+++ b/lib/services/HDInsight2/lib/hDInsightManagementClient.js
@@ -583,6 +583,9 @@ var ClusterOperations = ( /** @lends ClusterOperations */ function() {
    * @param {array} [clusterCreateParameters.properties.computeProfile.roles]
    * Gets or sets the list of roles in the cluster.
    * 
+   * @param {array} [clusterCreateParameters.properties.storageProfile.storageaccounts]
+   * Gets or sets the list of storage accounts associated with the cluster.
+   * 
    * @param {function} callback
    * 
    * @returns {Stream} The response stream.
@@ -837,6 +840,37 @@ var ClusterOperations = ( /** @lends ClusterOperations */ function() {
             }
           }
           computeProfileValue['roles'] = rolesArray;
+        }
+      }
+
+      if (clusterCreateParameters.properties.storageProfile !== null && clusterCreateParameters.properties.storageProfile !== undefined) {
+        var storageProfileValue = {};
+        propertiesValue['storageProfile'] = storageProfileValue;
+        
+        if (clusterCreateParameters.properties.storageProfile.storageaccounts !== null && clusterCreateParameters.properties.storageProfile.storageaccounts !== undefined) {
+          var storageaccountsArray = [];
+          for (var loweredIndex3 = 0; loweredIndex3 < clusterCreateParameters.properties.storageProfile.storageaccounts.length; loweredIndex3 = loweredIndex3 + 1) {
+            var storageaccountsItem = clusterCreateParameters.properties.storageProfile.storageaccounts[loweredIndex3];
+            var storageaccountValue = {};
+            storageaccountsArray.push(storageaccountValue);
+            
+            if (storageaccountsItem.name !== null && storageaccountsItem.name !== undefined) {
+              storageaccountValue['name'] = storageaccountsItem.name;
+            }
+
+            if (storageaccountsItem.isDefault !== null && storageaccountsItem.isDefault !== undefined) {
+              storageaccountValue['isDefault'] = storageaccountsItem.isDefault;
+            }
+
+            if (storageaccountsItem.container !== null && storageaccountsItem.container !== undefined) {
+              storageaccountValue['container'] = storageaccountsItem.container;
+            }
+
+            if (storageaccountsItem.key !== null && storageaccountsItem.key !== undefined) {
+              storageaccountValue['key'] = storageaccountsItem.key;
+            }
+          }
+          storageProfileValue['storageaccounts'] = storageaccountsArray;          
         }
       }
     }


### PR DESCRIPTION
When creating a new hd insight cluster, enabling to configure a storage profile and inside storage accounts associated with it.

This pull request resolves #1849 