### PR TITLE
fix urls in ms-rest-azure/package.json

### DIFF
--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -27,13 +27,13 @@
     "mocha": "2.4.5",
     "should": "5.2.0"
   },
-  "homepage": "https://github.com/Azure/AutoRest",
+  "homepage": "https://github.com/Azure/azure-sdk-for-node/blob/master/runtime/ms-rest-azure",
   "repository": {
     "type": "git",
-    "url": "git@github.com:Azure/AutoRest.git"
+    "url": "git@github.com:Azure/azure-sdk-for-node.git"
   },
   "bugs": {
-    "url": "http://github.com/Azure/AutoRest/issues"
+    "url": "https://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
     "test": "npm install && npm -s run-script jshint && npm -s run-script unit",


### PR DESCRIPTION
urls for homepage, repository and bugs updated

This is necessary to allow `npm home ms-rest-azure`, `npm repo ms-rest-azure` and `npm issues ms-rest-azure` to work properly.