### PR TITLE
#2009 - fix for SQL export method

### DIFF
--- a/lib/services/sqlManagement/lib/sqlManagementClient.js
+++ b/lib/services/sqlManagement/lib/sqlManagementClient.js
@@ -293,9 +293,13 @@ var DacOperations = ( /** @lends DacOperations */ function() {
         var blobCredentialsElement = js2xml.createElement('BlobCredentials', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
         js2xml.addChildElement(exportInputElement, blobCredentialsElement);
         
-        var typeAttribute = js2xml.createAttribute('type', 'http://www.w3.org/2001/XMLSchema-instance');
+        var typeAttribute = js2xml.createAttribute('p2:type', 'http://www.w3.org/2001/XMLSchema-instance');
         js2xml.setAttributeValue(typeAttribute, 'BlobStorageAccessKeyCredentials');
         js2xml.addAttribute(blobCredentialsElement, typeAttribute);
+
+        var xmlnsAttribute = js2xml.createAttribute('xmlns:p2', 'http://www.w3.org/2001/XMLSchema-instance');
+        js2xml.setAttributeValue(xmlnsAttribute, 'http://www.w3.org/2001/XMLSchema-instance');
+        js2xml.addAttribute(blobCredentialsElement, xmlnsAttribute);
         
         var uriElement = js2xml.createElement('Uri', 'http://schemas.datacontract.org/2004/07/Microsoft.SqlServer.Management.Dac.ServiceTypes');
         js2xml.setElementValue(uriElement, parameters.blobCredentials.uri);


### PR DESCRIPTION
This would add correct attributes for BlobCredentials element in sql export method request body.

SQL export documentation is available below.
https://msdn.microsoft.com/en-us/library/azure/dn781282.aspx