### PR TITLE
Package check for mac and other fixes

### DIFF
--- a/Extensions/azure-node-essentials/README.md
+++ b/Extensions/azure-node-essentials/README.md
@@ -5,23 +5,32 @@ This extension provides NodeJs tools for developers working with Azure SDKs.
 ## Feature List
 
 1. Project and file scaffolding
+   * `yo azure-node` to create 
+      * Javascript or Typescript project with package.json set up to target Azure SDKs
+      * Empty .js or .ts files
+      * pre populated .tsconfig or .jsconfig files
+      * create a service principal
 1. Snippets for some common operations such as authentication, creating a service principal.
+   * `loginInt` : generate code for interactive login
+   * `loginPwd` : generate code for logging in with username and password
+   * `loginSp`  : generate code for logging in with a service principal
+   * `spCreate` : generate code to create a service principal
 1. Code generation scenarios
-   * generate code for template deployment
+   * command `Azure-Node: Generate code for template deployment` : generate code for template deployment
 
 ### Sample workflow
 
-1. Open VS code with an empty workspace (no folder)
-2. Bring up VS code command palette, invoke `yo`
-3. Choose `azure-node` generator and invoke it.
-4. Choose `* app` to invoke the main generator (the sub generators for files are listed at the root level)
-5. Choose a Javascript project and proceed.
-6. This should initialize your project and install npm dependencies
-7. Meanwhile, open the folder in VSCode and navigate to index.js
-8. Notice that package.json has been set up and index.js has boiler plate code for authentication.
-9. Place caret on the line after `// TODO: Write your application logic here.`
-9. From VS Code's command palette, invoke `>Azure-Node: Generate code for template deployment`
-10. The extension generates code for template deployment.
+1. Open VS code with an empty workspace (empty folder)
+1. Bring up VS code command palette, invoke `yo`
+1. Choose `azure-node` generator and invoke it.
+1. Choose `* app` to invoke the main generator (the sub generators for files are listed at the root level)
+1. Choose a Javascript project and proceed.
+1. This should initialize your project and install npm dependencies
+1. Meanwhile, open the folder in VSCode and navigate to index.js
+1. Notice that package.json has been set up and index.js has boiler plate code for authentication.
+1. Place caret on the line after `// TODO: Write your application logic here.`
+1. From VS Code's command palette, invoke `>Azure-Node: Generate code for template deployment`
+1. The extension generates code for template deployment.
 
 ## Dependencies
 

--- a/Extensions/azure-node-essentials/changelog.md
+++ b/Extensions/azure-node-essentials/changelog.md
@@ -1,6 +1,16 @@
 # Change Log for Azure Node Essentials
 
-## 0.1.0-preview - 2017-02-07
+## 0.2.3 [2017-02-08]
+
+1. Bug fixes for Mac
+1. updates to readme
+1. check for generator package's version and upgrade if not latest
+
+## 0.2.0 - 0.2.2 [2017-02-07]
+
+1. No product change, updates to readme and other metadata about the project.
+
+## 0.1.0 [2017-02-07]
 
 1. Project and file scaffolding
 1. Snippets for some common operations such as authentication, creating a service principal.

--- a/Extensions/azure-node-essentials/extension.js
+++ b/Extensions/azure-node-essentials/extension.js
@@ -35,6 +35,7 @@ function ensureDependenciesAreInstalled() {
     // Download and install template generator package.
     var extensionName = 'Azure-Node-Essentials';
     var generatorPackageName = 'generator-azure-node';
+    var generatorPackageVersion = '0.1.0';
 
     isNodeInstalled().then(function (result) {
         if (!result) {
@@ -43,12 +44,12 @@ function ensureDependenciesAreInstalled() {
         }
 
         // check the npm cache on this machine and determine if our dependency is present.
-        // if the dependency is present, there is nothing more to do.
-        // if it is not present, install it from npm. 
+        // if the dependency is present and is the latest version, there is nothing more to do.
+        // if it is not present or is not the latest, install it from npm. 
         npmList().then(function (listOfPackages) {
             var present = listOfPackages.some(function (item) {
                 if (item.startsWith(generatorPackageName)) {
-                    return true;
+                    return item.split('@')[1] === generatorPackageVersion;
                 }
                 return false;
             });

--- a/Extensions/azure-node-essentials/extension.js
+++ b/Extensions/azure-node-essentials/extension.js
@@ -113,21 +113,29 @@ function npmList(path) {
             packages = stdout.split('\n');
 
             packages = packages.filter(function (item) {
-                if (item.match(/^\+--.+/g) != null) {
+                if (item.match(/^\+--.+/g) != null || item.match(/^├──.+/g) != null) {
                     return true;
                 }
-                if (item.match(/^`--.+/g) != null) {
+                if (item.match(/^`--.+/g) != null || item.match(/^└──.+/g) != null) {
                     return true;
                 }
                 return undefined;
             });
 
             packages = packages.map(function (item) {
+                // windows
                 if (item.match(/^\+--.+/g) != null) {
                     return item.replace(/^\+--\s/g, "");
                 }
                 if (item.match(/^`--.+/g) != null) {
                     return item.replace(/^`--\s/g, "");
+                }
+                // mac
+                if (item.match(/^├──.+/g) != null) {
+                    return item.replace(/^├──\s/g, "");
+                }
+                if (item.match(/^└──.+/g) != null) {
+                    return item.replace(/^└──\s/g, "");
                 }
             })
             resolve(packages);

--- a/Extensions/azure-node-essentials/package.json
+++ b/Extensions/azure-node-essentials/package.json
@@ -2,7 +2,7 @@
     "name": "azurenodeessentials",
     "displayName": "Azure Node Essentials",
     "description": "Azure Node SDK Essentials for VS Code",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "azuresdkteam",
     "engines": {
         "vscode": "^1.8.0"


### PR DESCRIPTION
1. Fixing an annoying bug in mac, where we would always update the package on every instance of VSCode activation.
2. updated readme with more scenarios