### PR TITLE
msrest - send user agent info in request headers

### DIFF
--- a/runtime/ms-rest/lib/constants.js
+++ b/runtime/ms-rest/lib/constants.js
@@ -64,7 +64,15 @@ var Constants = {
     */
     AUTHORIZATION: 'authorization',
 
-    AUTHORIZATION_SCHEME: 'Bearer'
+    AUTHORIZATION_SCHEME: 'Bearer',
+
+    /**
+    * The UserAgent header.
+    *
+    * @const
+    * @type {string}
+    */
+    USER_AGENT: 'user-agent',
   }
 };
 

--- a/runtime/ms-rest/lib/filters/userAgentFilter.js
+++ b/runtime/ms-rest/lib/filters/userAgentFilter.js
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+var os = require('os');
+var util = require('util');
+var Constants = require('../constants');
+var HeaderConstants = Constants.HeaderConstants;
+
+/**
+* Creates a filter to add the user agent header in a request.
+*
+* @param {string} userAgent The user agent string to use.
+*/
+exports.create = function (userAgentInfo) {
+  return function handle(resource, next, callback) {
+    if (!resource.headers[HeaderConstants.USER_AGENT]) {
+      exports._tagRequest(resource, userAgentInfo);
+    }
+
+    return next(resource, callback);
+  };
+};
+
+exports._tagRequest = function (requestOptions, userAgentInfo) {
+  var runtimeInfo = `Node/${process.version}`;
+  var osInfo = `(${os.arch()}-${os.type()}-${os.release()})`;
+
+  userAgentInfo.unshift(runtimeInfo, osInfo);
+  requestOptions.headers[HeaderConstants.USER_AGENT] = userAgentInfo.join(' ');
+};

--- a/runtime/ms-rest/lib/filters/userAgentFilter.js
+++ b/runtime/ms-rest/lib/filters/userAgentFilter.js
@@ -22,9 +22,8 @@ exports.create = function (userAgentInfo) {
 };
 
 exports.tagRequest = function (requestOptions, userAgentInfo) {
-  var runtimeInfo = `Node/${process.version}`;
-  var osInfo = `(${os.arch()}-${os.type()}-${os.release()})`;
-
+  var runtimeInfo = util.format('Node/%s', process.version);
+  var osInfo = util.format('(%s-%s-%s)', os.arch(), os.type(), os.release());
   userAgentInfo.unshift(runtimeInfo, osInfo);
   requestOptions.headers[HeaderConstants.USER_AGENT] = userAgentInfo.join(' ');
 };

--- a/runtime/ms-rest/lib/filters/userAgentFilter.js
+++ b/runtime/ms-rest/lib/filters/userAgentFilter.js
@@ -14,14 +14,14 @@ var HeaderConstants = Constants.HeaderConstants;
 exports.create = function (userAgentInfo) {
   return function handle(resource, next, callback) {
     if (!resource.headers[HeaderConstants.USER_AGENT]) {
-      exports._tagRequest(resource, userAgentInfo);
+      exports.tagRequest(resource, userAgentInfo);
     }
 
     return next(resource, callback);
   };
 };
 
-exports._tagRequest = function (requestOptions, userAgentInfo) {
+exports.tagRequest = function (requestOptions, userAgentInfo) {
   var runtimeInfo = `Node/${process.version}`;
   var osInfo = `(${os.arch()}-${os.type()}-${os.release()})`;
 

--- a/runtime/ms-rest/lib/msRest.js
+++ b/runtime/ms-rest/lib/msRest.js
@@ -17,6 +17,7 @@ exports.ProxyFilter = require('./filters/proxyFilter');
 exports.LogFilter = require('./filters/logFilter');
 exports.SigningFilter = require('./filters/signingFilter');
 exports.ExponentialRetryPolicyFilter = require('./filters/exponentialRetryPolicyFilter');
+exports.UserAgentFilter = require('./filters/userAgentFilter');
 
 exports.requestPipeline = require('./requestPipeline');
 exports.stripResponse = utils.stripResponse;

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -13,6 +13,7 @@ var ExponentialRetryPolicyFilter = require('./filters/exponentialRetryPolicyFilt
 var SystemErrorRetryPolicyFilter = require('./filters/systemErrorRetryPolicyFilter');
 var requestPipeline = require('./requestPipeline');
 var WebResource = require('./webResource');
+var util = require('util');
 var utils = require('./utils');
 var packageJson = require('../package.json');
 var moduleName = packageJson.name;
@@ -53,7 +54,7 @@ function ServiceClient(credentials, options) {
     throw new Error('credentials argument needs to implement signRequest method');
   }
 
-  this.addUserAgentInfo(`${moduleName}/${moduleVersion}`);
+  this.addUserAgentInfo(util.format('%s/%s', moduleName, moduleVersion));
 
   if (credentials) {
     options.filters.push(SigningFilter.create(credentials));

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -18,8 +18,6 @@ var packageJson = require('../package.json');
 var moduleName = packageJson.name;
 var moduleVersion = packageJson.version;
 
-var userAgentInfo;
-
 /**
  * @class
  * Initializes a new instance of the ServiceClient class.
@@ -49,7 +47,7 @@ function ServiceClient(credentials, options) {
     options.filters = [];
   }
 
-  userAgentInfo = [];
+  this.userAgentInfo.value = [];
 
   if (credentials && !credentials.signRequest) {
     throw new Error('credentials argument needs to implement signRequest method');
@@ -61,7 +59,7 @@ function ServiceClient(credentials, options) {
     options.filters.push(SigningFilter.create(credentials));
   }
 
-  options.filters.push(UserAgentFilter.create(userAgentInfo));
+  options.filters.push(UserAgentFilter.create(this.userAgentInfo.value));
   options.filters.push(RedirectFilter.create());
   if (!options.noRetryPolicy) {
     options.filters.push(new ExponentialRetryPolicyFilter());
@@ -245,8 +243,19 @@ ServiceClient.prototype.sendRequest = function sendRequest(options, callback) {
   });
 };
 
+/**
+ * property to store various pieces of information we would finally concat to produce a user-agent header.
+ */
+ServiceClient.prototype.userAgentInfo = {
+  value: []
+};
+
+/**
+ * Adds custom information to user agent header
+ * @param {any} additionalUserAgentInfo - information to be added to user agent header, as string.
+ */
 ServiceClient.prototype.addUserAgentInfo = function addUserAgentInfo(additionalUserAgentInfo) {
-  userAgentInfo.push(additionalUserAgentInfo);
+  this.userAgentInfo.value.push(additionalUserAgentInfo);
 };
 
 module.exports = ServiceClient;


### PR DESCRIPTION
These are the runtime changes required to send userAgent string in request headers. See issue #2076

This adds a `addUserAgentInfo` to the service client which is the base class for any concrete azure service client. So, autorest generated service clients or any 3rd party libraries can simply call this method and pass in their package name and module version in the format `module_name/package_version`.

The runtime then constructs the user agent string via an user agent filter as part of the request pipeline and sends it along.

This is part 1 of the runtime changes. See #2078 for why runtime changes need to be made independently.