### PR TITLE
get info from package json

### DIFF
--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -265,7 +265,8 @@ ServiceClient.prototype.addUserAgentInfo = function addUserAgentInfo(additionalU
  * Attempts to find package.json for the given azure nodejs package.
  * If found, returns the name and version of the package by reading the package.json
  * If package.json is not found, returns a default value.
- * @param {any} managementClientDir - pass the directory of the specific azure management client.
+ * @param {string} managementClientDir - pass the directory of the specific azure management client.
+ * @returns {object} packageJsonInfo - "name" and "version" of the desired package.
  */
 ServiceClient.prototype.getPackageJsonInfo = function getPackageJsonInfo(managementClientDir) {
 
@@ -278,10 +279,9 @@ ServiceClient.prototype.getPackageJsonInfo = function getPackageJsonInfo(managem
   // The algorithm for locating package.json would then be, start at the current directory where management client lives
   // and keep searching up until the file is located. We also limit the search depth to 2, since we know the structure of 
   // the clients we generate.
-  //
 
   var packageJsonInfo = {
-    name: 'default',
+    name: 'NO_NAME',
     version: '0.0.0'
   };
 

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -302,21 +302,10 @@ function _getLibPath(currentDir, searchDepth) {
     return;
   }
 
-  if (_isLibPath(currentDir)) {
-    return currentDir;
-  }
-  else {
-    // try one level up
-    return _getLibPath(path.join(currentDir, '..'), searchDepth - 1);
-  }
-};
-
-function _isLibPath(currentDir) {
-  var libDir = 'lib';
-
-  return currentDir.endsWith(path.sep) ?
-    currentDir.endsWith(libDir + path.sep) :
-    currentDir.endsWith(libDir);
+  // if current directory is lib, return current dir, otherwise search one level up.
+  return (currentDir.endsWith('lib') || currentDir.endsWith('lib' + path.sep))
+    ? currentDir
+    : _getLibPath(path.join(currentDir, '..'), searchDepth - 1);
 };
 
 module.exports = ServiceClient;

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -15,6 +15,8 @@ var requestPipeline = require('./requestPipeline');
 var WebResource = require('./webResource');
 var util = require('util');
 var utils = require('./utils');
+var path = require('path');
+var fs = require('fs');
 var packageJson = require('../package.json');
 var moduleName = packageJson.name;
 var moduleVersion = packageJson.version;
@@ -303,9 +305,9 @@ function _getLibPath(currentDir, searchDepth) {
   }
 
   // if current directory is lib, return current dir, otherwise search one level up.
-  return (currentDir.endsWith('lib') || currentDir.endsWith('lib' + path.sep))
-    ? currentDir
-    : _getLibPath(path.join(currentDir, '..'), searchDepth - 1);
-};
+  return (currentDir.endsWith('lib') || currentDir.endsWith('lib' + path.sep)) ?
+    currentDir :
+    _getLibPath(path.join(currentDir, '..'), searchDepth - 1);
+}
 
 module.exports = ServiceClient;


### PR DESCRIPTION
This is part of work for https://github.com/Azure/azure-sdk-for-node/issues/2076

Motivation:
To send user agent information from azure packages, we have to read its package.json. It turns out that package.json isn't always in the same relative path from the service client itself. So, this helper on the base service client helps to locate package.json and send back the required info. This will be consumed by azure clients generated from autorest.