### PR TITLE
bump up version number for runtime packages

### DIFF
--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "1.15.5",
+  "version": "1.15.6",
   "description": "Client Runtime for Node.js Azure client libraries generated using AutoRest",
   "tags": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
   "keywords": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
@@ -16,7 +16,7 @@
     "async": "0.2.7",
     "uuid": "^3.0.1",
     "adal-node": "^0.1.17",
-    "ms-rest": "^1.15.5",
+    "ms-rest": "^1.15.6",
     "moment": "^2.14.1",
     "azure-arm-resource": "^1.6.1-preview"
   },

--- a/runtime/ms-rest/package.json
+++ b/runtime/ms-rest/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "1.15.5",
+  "version": "1.15.6",
   "description": "Client Runtime for Node.js client libraries generated using AutoRest",
   "tags": ["node", "microsoft", "autorest", "clientruntime"],
   "keywords": ["node", "microsoft", "autorest", "clientruntime"],


### PR DESCRIPTION
after my previous change to expose a way to read package.json for
telemetry data.

This is part of work for https://github.com/Azure/azure-sdk-for-node/issues/2076
patch version needs to be bumped up due to this change: https://github.com/Azure/azure-sdk-for-node/pull/2084