### PR TITLE
update patch version for msrest

### DIFF
--- a/runtime/ms-rest/package.json
+++ b/runtime/ms-rest/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "1.15.5",
+  "version": "1.15.6",
   "description": "Client Runtime for Node.js client libraries generated using AutoRest",
   "tags": ["node", "microsoft", "autorest", "clientruntime"],
   "keywords": ["node", "microsoft", "autorest", "clientruntime"],


### PR DESCRIPTION
after my previous change to expose a way to read package.json for
telemetry data.

This is part of work for #2076
patch version needs to be bumped up due to this change: #2084