### PR TITLE
update patch version for msrestazure

### DIFF
--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "1.15.5",
+  "version": "1.15.6",
   "description": "Client Runtime for Node.js Azure client libraries generated using AutoRest",
   "tags": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
   "keywords": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
@@ -16,7 +16,7 @@
     "async": "0.2.7",
     "uuid": "^3.0.1",
     "adal-node": "^0.1.17",
-    "ms-rest": "^1.15.5",
+    "ms-rest": "^1.15.6",
     "moment": "^2.14.1",
     "azure-arm-resource": "^1.6.1-preview"
   },


### PR DESCRIPTION
after my previous change to expose a way to read package.json for
telemetry data.

This is part of work for #2076
patch version needs to be bumped up due to this change: #2084