### PR TITLE
Fixes for user agent header

### DIFF
--- a/runtime/ms-rest/lib/filters/userAgentFilter.js
+++ b/runtime/ms-rest/lib/filters/userAgentFilter.js
@@ -13,17 +13,29 @@ var HeaderConstants = Constants.HeaderConstants;
 */
 exports.create = function (userAgentInfo) {
   return function handle(resource, next, callback) {
+    // This filter must be excuted last, before the request is sent over the wire.
+    // So, we call the next filter in the chain and finally when the call stack unwinds
+    // we tag the request with our payload.
+    var rest = next(resource, callback);
+    
     if (!resource.headers[HeaderConstants.USER_AGENT]) {
       exports.tagRequest(resource, userAgentInfo);
     }
 
-    return next(resource, callback);
+    return rest;
   };
 };
 
 exports.tagRequest = function (requestOptions, userAgentInfo) {
-  var runtimeInfo = util.format('Node/%s', process.version);
   var osInfo = util.format('(%s-%s-%s)', os.arch(), os.type(), os.release());
-  userAgentInfo.unshift(runtimeInfo, osInfo);
+  if(!userAgentInfo.includes(osInfo)){
+    userAgentInfo.unshift(osInfo);
+  }
+
+  var runtimeInfo = util.format('Node/%s', process.version);
+  if(!userAgentInfo.includes(runtimeInfo)){
+    userAgentInfo.unshift(runtimeInfo);
+  }
+  
   requestOptions.headers[HeaderConstants.USER_AGENT] = userAgentInfo.join(' ');
 };

--- a/runtime/ms-rest/lib/filters/userAgentFilter.js
+++ b/runtime/ms-rest/lib/filters/userAgentFilter.js
@@ -28,12 +28,12 @@ exports.create = function (userAgentInfo) {
 
 exports.tagRequest = function (requestOptions, userAgentInfo) {
   var osInfo = util.format('(%s-%s-%s)', os.arch(), os.type(), os.release());
-  if(!userAgentInfo.includes(osInfo)){
+  if(userAgentInfo.indexOf(osInfo) === -1){
     userAgentInfo.unshift(osInfo);
   }
 
   var runtimeInfo = util.format('Node/%s', process.version);
-  if(!userAgentInfo.includes(runtimeInfo)){
+  if(userAgentInfo.indexOf(runtimeInfo) === -1){
     userAgentInfo.unshift(runtimeInfo);
   }
   

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -258,7 +258,9 @@ ServiceClient.prototype.userAgentInfo = {
  * @param {any} additionalUserAgentInfo - information to be added to user agent header, as string.
  */
 ServiceClient.prototype.addUserAgentInfo = function addUserAgentInfo(additionalUserAgentInfo) {
-  this.userAgentInfo.value.push(additionalUserAgentInfo);
+  if (!this.userAgentInfo.value.includes(additionalUserAgentInfo)) {
+    this.userAgentInfo.value.push(additionalUserAgentInfo);
+  }
 };
 
 /**

--- a/runtime/ms-rest/lib/serviceClient.js
+++ b/runtime/ms-rest/lib/serviceClient.js
@@ -258,7 +258,7 @@ ServiceClient.prototype.userAgentInfo = {
  * @param {any} additionalUserAgentInfo - information to be added to user agent header, as string.
  */
 ServiceClient.prototype.addUserAgentInfo = function addUserAgentInfo(additionalUserAgentInfo) {
-  if (!this.userAgentInfo.value.includes(additionalUserAgentInfo)) {
+  if (this.userAgentInfo.value.indexOf(additionalUserAgentInfo) === -1) {
     this.userAgentInfo.value.push(additionalUserAgentInfo);
   }
 };

--- a/runtime/ms-rest/package.json
+++ b/runtime/ms-rest/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "1.15.6",
+  "version": "1.15.7",
   "description": "Client Runtime for Node.js client libraries generated using AutoRest",
   "tags": ["node", "microsoft", "autorest", "clientruntime"],
   "keywords": ["node", "microsoft", "autorest", "clientruntime"],


### PR DESCRIPTION
1. ensure that this filter is executed last and other user-agent
filters, if any (xplat-cli has its own) are executed first. That way,
the right user agent header is set. So we call the other filters in the
chain first and apply our function when the callstack unwinds. By now,
if another filter had set the user agent header, we wont bother setting
it.

2. check if a particular bit of useragent info is already present before
inserting it. safe fix for #2091