### PR TITLE
Update engine restriction in azure-arm-intune

### DIFF
--- a/lib/services/intune/package.json
+++ b/lib/services/intune/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "./lib/intuneResourceManagementClient.js",
   "engines": {
-    "node": "^5.0.0"
+    "node": ">=5.0.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Updated the engine restriction in azure-arm-intune to allow for modern versions of node (v5+) instead of only v5.

Issue: https://github.com/Azure/azure-sdk-for-node/issues/1935