### PR TITLE
KeyVaultCredentials type definition fixes: (1) constructor keyword mi…

### DIFF
--- a/lib/services/keyVault/lib/keyvault.d.ts
+++ b/lib/services/keyVault/lib/keyvault.d.ts
@@ -42,7 +42,7 @@ export interface Authenticator {
  * @param {KeyVaultCredentials~authRequest} authenticator  A callback that receives a challenge and returns an authentication token.
  */
 export class KeyVaultCredentials implements msRest.ServiceClientCredentials {
-  cosntructor(authenticator: Authenticator);
+  constructor( authenticator:  (challenge: any, callback: any) => any );
   signRequest(webResource: msRest.WebResource, callback: { (err: Error): void }): void;
 }
 


### PR DESCRIPTION
KeyVaultCredentials type definition fixes: (1) constructor keyword misspelled, (2) type parameters not matching expected runtime parameter

This is a rather critical build stopping issue for us, we are not able to 'patch' the class type definition in our code, as  class merging does not work same way as interface merging. 