### PR TITLE
corrected import stmt names in ts file to match dataLakeStore.js

### DIFF
--- a/lib/services/dataLake.Store/lib/datalakeStore.d.ts
+++ b/lib/services/dataLake.Store/lib/datalakeStore.d.ts
@@ -4,11 +4,11 @@
  * license information.
  */
 
-import DataLakeStoreAccountManagementClient = require('./account/dataLakeStoreAccountManagementClient');
+import DataLakeStoreAccountClient = require('./account/dataLakeStoreAccountClient');
 import * as StoreAccountModels from './account/models';
 
-import DataLakeStoreFileSystemManagementClient = require('./filesystem/dataLakeStoreFileSystemManagementClient');
+import DataLakeStoreFileSystemClient = require('./filesystem/dataLakeStoreFileSystemClient');
 import * as FileSystemModels from './filesystem/models';
 
 
-export { DataLakeStoreAccountManagementClient, StoreAccountModels, DataLakeStoreFileSystemManagementClient, FileSystemModels };
+export { DataLakeStoreAccountClient, StoreAccountModels, DataLakeStoreFileSystemClient, FileSystemModels };


### PR DESCRIPTION
This fixes typescript compile issue due to naming mismatch between d.ts and associated js files.

Changed the property names in the dataLakeStore.d.ts file to match the associated dataLakeStore.js file