### PR TITLE
changes to ms-rest

### DIFF
--- a/runtime/ms-rest-azure/Changelog.md
+++ b/runtime/ms-rest-azure/Changelog.md
@@ -1,3 +1,6 @@
+### 2.1.2 (4/29/2017)
+- Updated minimum dependency on `"ms-rest"` to `"^2.2.0"` to ensure the new fixes in ms-rest are consumed.
+
 ### 2.1.1 (4/14/2017)
 - Updated minimum dependency on `"ms-rest"` to `"^2.1.0"` to ensure the new fixes in ms-rest are consumed.
 

--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Client Runtime for Node.js Azure client libraries generated using AutoRest",
   "tags": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
   "keywords": [ "node", "microsoft", "autorest", "azure", "clientruntime" ],
@@ -16,7 +16,7 @@
     "async": "0.2.7",
     "uuid": "^3.0.1",
     "adal-node": "^0.1.17",
-    "ms-rest": "^2.1.0",
+    "ms-rest": "^2.2.0",
     "moment": "^2.14.1",
     "@types/uuid": "^2.0.29",
     "@types/node": "^7.0.10"

--- a/runtime/ms-rest/Changelog.md
+++ b/runtime/ms-rest/Changelog.md
@@ -1,3 +1,6 @@
+### 2.2.0 (4/29/2017)
+- Minor bug fix in `WebResource.prepare()` while processing query parameters
+- Removed native references to `Buffer.isBuffer()` and stream and replaced it with packages that are browser compatible.
 ### 2.1.0 (4/14/2017)
 - Ensured `'use strict';` is applied correctly in all the files #2131
 - Modified the handling of `Content-Type` request header in `Webresource.prepare()` #2126

--- a/runtime/ms-rest/lib/serialization.js
+++ b/runtime/ms-rest/lib/serialization.js
@@ -4,7 +4,8 @@
 'use strict';
 
 const moment = require('moment');
-const stream = require('stream');
+const isStream = require('is-stream');
+const isBuffer = require('is-buffer');
 const utils = require('./utils');
 
 /**
@@ -18,7 +19,7 @@ const utils = require('./utils');
  */
 exports.serializeObject = function (toSerialize) {
   if (toSerialize === null || toSerialize === undefined) return null;
-  if (Buffer.isBuffer(toSerialize)) {
+  if (isBuffer(toSerialize)) {
     toSerialize = toSerialize.toString('base64');
     return toSerialize;
   }
@@ -270,7 +271,7 @@ function serializeBasicTypes(typeName, objectName, value) {
         throw new Error(`${objectName} must be of type object.`);
       }
     }  else if (typeName.match(/^Stream$/ig) !== null) {
-      if (value instanceof stream.Stream) {
+      if (isStream(value)) {
         throw new Error(`${objectName} must be of type stream.`);
       }
     }
@@ -296,7 +297,7 @@ function serializeEnumType(objectName, allowedValues, value) {
 
 function serializeBufferType(objectName, value) {
   if (value !== null && value !== undefined) {
-    if (!Buffer.isBuffer(value)) {
+    if (!isBuffer(value)) {
       throw new Error(`${objectName} must be of type Buffer.`);
     }
     value = value.toString('base64');
@@ -306,7 +307,7 @@ function serializeBufferType(objectName, value) {
 
 function serializeBase64UrlType(objectName, value) {
   if (value !== null && value !== undefined) {
-    if (!Buffer.isBuffer(value)) {
+    if (!isBuffer(value)) {
       throw new Error(`${objectName} must be of type Buffer.`);
     }
     value = bufferToBase64Url(value);
@@ -611,7 +612,7 @@ function bufferToBase64Url(buffer) {
   if (!buffer) {
     return null;
   }
-  if (!Buffer.isBuffer(buffer)) {
+  if (!isBuffer(buffer)) {
     throw new Error(`Please provide an input of type Buffer for converting to Base64Url.`);
   }
   // Buffer to Base64.

--- a/runtime/ms-rest/lib/webResource.js
+++ b/runtime/ms-rest/lib/webResource.js
@@ -223,16 +223,16 @@ class WebResource {
             queryParams.push(queryParamName + '=' + encodeURIComponent(queryParam));
             this.query[queryParamName] = encodeURIComponent(queryParam);
           }
-          if (typeof queryParam === 'object') {
+          else if (typeof queryParam === 'object') {
             if (!queryParam.value) {
               throw new Error(`options.queryParameters[${queryParamName}] is of type "object" but it does not contain a "value" property.`);
             }
             if (queryParam.skipUrlEncoding) {
-              queryParams.push(queryParamName + '=' + queryParameters[queryParamName]);
-              this.query[queryParamName] = queryParameters[queryParamName];
+              queryParams.push(queryParamName + '=' + queryParam.value);
+              this.query[queryParamName] = queryParam.value;
             } else {
-              queryParams.push(queryParamName + '=' + encodeURIComponent(queryParameters[queryParamName]));
-              this.query[queryParamName] = encodeURIComponent(queryParameters[queryParamName]);
+              queryParams.push(queryParamName + '=' + encodeURIComponent(queryParam.value));
+              this.query[queryParamName] = encodeURIComponent(queryParam.value);
             }
           }
         }

--- a/runtime/ms-rest/package.json
+++ b/runtime/ms-rest/package.json
@@ -5,23 +5,35 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Client Runtime for Node.js client libraries generated using AutoRest",
-  "tags": ["node", "microsoft", "autorest", "clientruntime"],
-  "keywords": ["node", "microsoft", "autorest", "clientruntime"],
+  "tags": [
+    "node",
+    "microsoft",
+    "autorest",
+    "clientruntime"
+  ],
+  "keywords": [
+    "node",
+    "microsoft",
+    "autorest",
+    "clientruntime"
+  ],
   "main": "./lib/msRest.js",
   "types": "./index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "tunnel": "~0.0.2",
-    "request": "^2.74.0",
-    "duplexer": "~0.1.1",
-    "through": "~2.3.4",
-    "moment": "^2.14.1",
-    "uuid": "^3.0.1",
+    "@types/node": "^7.0.10",
     "@types/request": "^0.0.42",
     "@types/uuid": "^2.0.29",
-    "@types/node": "^7.0.10"
+    "duplexer": "~0.1.1",
+    "is-buffer": "^1.1.5",
+    "is-stream": "^1.1.0",
+    "moment": "^2.14.1",
+    "request": "^2.74.0",
+    "through": "~2.3.4",
+    "tunnel": "~0.0.2",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "jshint": "2.9.4",


### PR DESCRIPTION
- fixes this https://github.com/Azure/oav/issues/111
- removed native code `Buffer.isBuffer()` and replaced it with a browser compatible package.