### PR TITLE
doc fix, param incorrectly implied delete occurs

### DIFF
--- a/lib/services/serviceBus/lib/servicebusservice.js
+++ b/lib/services/serviceBus/lib/servicebusservice.js
@@ -553,7 +553,7 @@ ServiceBusService.prototype._receiveMessage = function (path, optionsOrCallback,
 /**
 * Creates a queue.
 *
-* @param {string}             queuePath                                             A string object that represents the name of the queue to delete.
+* @param {string}             queuePath                                             A string object that represents the name of the queue to create.
 * @param {object}             [options]                                             The request options.
 * @param {int}                [options.MaxSizeInMegaBytes]                          Specifies the maximum queue size in megabytes. Any attempt to enqueue a message that will cause the queue to exceed this value will fail.
 * @param {PTnHnMnS}           [options.DefaultMessageTimeToLive]                    Depending on whether DeadLettering is enabled, a message is automatically moved to the DeadLetterQueue or deleted if it has been stored in the queue for longer than the specified time. This value is overwritten by a TTL specified on the message if and only if the message TTL is smaller than the TTL set on the queue. This value is immutable after the Queue has been created.


### PR DESCRIPTION
This function creates a queue, but the documentation for the `queuePath` param implies delete. Corrected.