### PR TITLE
Add innerError field to CloudError contract

### DIFF
--- a/runtime/ms-rest-azure/lib/cloudError.js
+++ b/runtime/ms-rest-azure/lib/cloudError.js
@@ -14,6 +14,8 @@
  * @member {string} [target] The target of the error
  * 
  * @member {array} [details] An array of CloudError objects specifying the details
+ * 
+ * @member {Object} [innerError] The inner error parsed from the body of the http error response
  */
 class CloudError extends Error {
   constructor(parameters) {
@@ -42,6 +44,10 @@ class CloudError extends Error {
           tempDetails.push(element);
         });
         this.details = tempDetails;
+      }
+
+      if (parameters.innerError) {
+        this.innerError = JSON.parse(JSON.stringify(parameters.innerError));
       }
     }
   }
@@ -95,11 +101,19 @@ class CloudError extends Error {
                 }
               }
             }
+          },
+          innerError: {
+            required: false,
+            serializedName: 'innerError',
+            type: {
+              name: 'Object'
+            }
           }
         }
       }
     };
   }
+
   /**
    * Serialize the instance to CloudError schema
    *
@@ -129,6 +143,10 @@ class CloudError extends Error {
         deserializedArray.push(element1);
       });
       payload.error.details = deserializedArray;
+    }
+
+    if (this.innerError) {
+      payload.error.innerError = JSON.parse(JSON.stringify(this.innerError));
     }
     return payload;
   }
@@ -165,6 +183,10 @@ class CloudError extends Error {
             deserializedArray.push(element1);
           });
           this.details = deserializedArray;
+        }
+        
+        if (instance.error.innerError) {
+          this.innerError = JSON.parse(JSON.stringify(instance.error.innerError));
         }
       }
     }

--- a/runtime/ms-rest-azure/lib/cloudError.js
+++ b/runtime/ms-rest-azure/lib/cloudError.js
@@ -15,7 +15,7 @@
  * 
  * @member {array} [details] An array of CloudError objects specifying the details
  * 
- * @member {Object} [innerError] The inner error parsed from the body of the http error response
+ * @member {Object} [innererror] The inner error parsed from the body of the http error response
  */
 class CloudError extends Error {
   constructor(parameters) {
@@ -46,8 +46,8 @@ class CloudError extends Error {
         this.details = tempDetails;
       }
 
-      if (parameters.innerError) {
-        this.innerError = JSON.parse(JSON.stringify(parameters.innerError));
+      if (parameters.innererror) {
+        this.innererror = JSON.parse(JSON.stringify(parameters.innererror));
       }
     }
   }
@@ -102,9 +102,9 @@ class CloudError extends Error {
               }
             }
           },
-          innerError: {
+          innererror: {
             required: false,
-            serializedName: 'innerError',
+            serializedName: 'innererror',
             type: {
               name: 'Object'
             }
@@ -145,8 +145,8 @@ class CloudError extends Error {
       payload.error.details = deserializedArray;
     }
 
-    if (this.innerError) {
-      payload.error.innerError = JSON.parse(JSON.stringify(this.innerError));
+    if (this.innererror) {
+      payload.error.innererror = JSON.parse(JSON.stringify(this.innererror));
     }
     return payload;
   }
@@ -185,8 +185,8 @@ class CloudError extends Error {
           this.details = deserializedArray;
         }
         
-        if (instance.error.innerError) {
-          this.innerError = JSON.parse(JSON.stringify(instance.error.innerError));
+        if (instance.error.innererror) {
+          this.innererror = JSON.parse(JSON.stringify(instance.error.innererror));
         }
       }
     }


### PR DESCRIPTION
ARM error schema conforms to the [OData 4.0](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091) spec, which declares the innerError field as an extension point.

I'm working on Azure Policy, and there is an upcoming change to ARM after which any PUT/PATCH request to any resource provider may return an error containing the innerError field in case the request is violating one of the policies. Because it's a part of ARM contract and is not specific to an RP, CloudError contract should be the right place for this change.