### PR TITLE
azure-sb: updated 'mpns' module

### DIFF
--- a/lib/services/serviceBus/package.json
+++ b/lib/services/serviceBus/package.json
@@ -27,7 +27,7 @@
     "azure-common": "^0.9.14",
     "underscore": "^1.8.3",
     "wns": "~0.5.3",
-    "mpns": "~2.0.0"
+    "mpns": "2.1.3"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {


### PR DESCRIPTION
This moves to the latest version of the mpns module, version 2.1.3.
The module has no changes other than incrementing the version and
updating the package.json to include the "license" property. This is
to help make it clear that the mpns module has the MIT license at
this time, making automated security and copyright analysis easy!

I am the author of the 'mpns' module, FYI.