### PR TITLE
Added script for installing local runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,6 +2575,25 @@
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3791,6 +3810,24 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -7166,6 +7203,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "devDependencies": {
     "adal-node": "^0.1.22",
+    "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "grunt": "~0.4",
     "grunt-contrib-connect": "^0.10.1",
@@ -161,7 +162,7 @@
     "url": "http://github.com/Azure/azure-sdk-for-node/issues"
   },
   "scripts": {
-    "test": "npm -s run-script jshint && npm -s run-script unit-msrestazure && npm -s run-script unit-arm && npm -s run-script unit && npm -s run-script unit-msrest",
+    "test": "npm -s run runtime-install && npm -s run jshint && npm -s run unit-msrestazure && npm -s run unit-arm && npm -s run unit && npm -s run unit-msrest",
     "unit": "node scripts/unit.js testlist.txt",
     "unit-arm": "node scripts/unit-arm.js testlistarm.txt",
     "unit-msrest": "cd runtime/ms-rest && npm test",
@@ -169,6 +170,7 @@
     "setup": "node scripts/setup.js",
     "jshint": "jshint lib --reporter=jslint",
     "ci": "node scripts/unit.js testlist.txt",
+    "runtime-install": "node scripts/runtime-install.js",
     "coverage": "node scripts/unit-coverage.js testlistarm.txt testlist.txt",
     "debug": "node --inspect scripts/unit-arm.js testlistarm.txt"
   }

--- a/scripts/runtime-install.js
+++ b/scripts/runtime-install.js
@@ -1,0 +1,26 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const msRestInstallPath = path.join(__dirname, '../node_modules/ms-rest');
+const msRestRuntimePath = path.join(__dirname, '../runtime/ms-rest');
+
+const msRestAzureInstallPath = path.join(__dirname, '../node_modules/ms-rest-azure');
+const msRestAzureRuntimePath = path.join(__dirname, '../runtime/ms-rest-azure');
+
+const filterFunc = (src, dest) => {
+  return src.match(/.*node_modules.*/i) === null;
+}
+
+fs.remove(msRestInstallPath, err => {
+  if (err) return console.error(err)
+  fs.copy(msRestRuntimePath, msRestInstallPath, { filter: filterFunc }, err => {
+    if (err) return console.error(err);
+  });
+});
+
+fs.remove(msRestAzureInstallPath, err => {
+  if (err) return console.error(err)
+  fs.copy(msRestAzureRuntimePath, msRestAzureInstallPath, { filter: filterFunc }, err => {
+    if (err) return console.error(err);
+  });
+});


### PR DESCRIPTION
-`npm run runtime-install`: will remove the `ms-rest` and ms-rest-azure` node_modules and connect the local versions of each.

-script will also be run as part of `npm test` 