### PR TITLE
fix typo while declaring AzurePublicCloudEnvironment

### DIFF
--- a/lib/azure.js
+++ b/lib/azure.js
@@ -3004,7 +3004,7 @@ exports.loginWithUsernamePassword = msRestAzure.loginWithUsernamePassword;
  * @property {string} azureDataLakeStoreFileSystemEndpointSuffix 'azuredatalakestore.net',
  * @property {string} azureDataLakeAnalyticsCatalogAndJobEndpointSuffix 'azuredatalakeanalytics.net'
  */ 
-exports.AzurePublicCloudEnvironment = msRestAzure.AzureEnvironment.Aure;
+exports.AzurePublicCloudEnvironment = msRestAzure.AzureEnvironment.Azure;
 
 /**
  * @typedef {object} AzureChinaCloudEnvironment


### PR DESCRIPTION
AzureEnvironment name fixed
- msRestAzure.AzureEnvironment.Aure -> msRestAzure.AzureEnvironment.Azure