### PR TITLE
Addition of service principal auth support for key vault

### DIFF
--- a/lib/services/keyVault/lib/keyVault.js
+++ b/lib/services/keyVault/lib/keyVault.js
@@ -190,6 +190,10 @@ function _getPendingCertificateSigningRequest(vaultBaseUrl, certificateName, opt
 class KeyVaultClient {
 
   constructor(credentials, options) {
+    if (! (credentials instanceof kvcreds.KeyVaultCredentials)) {
+        credentials = new kvcreds.KeyVaultCredentials(credentials);
+    }
+    
     if (credentials.createSigningFilter) {
       if (!options) options = [];
       if (!options.filters) options.filters = [];

--- a/lib/services/keyVault/lib/keyVaultCredentials.js
+++ b/lib/services/keyVault/lib/keyVaultCredentials.js
@@ -25,11 +25,35 @@ var requestPipeline = msRest.requestPipeline;
 /**
  * An object that performs authentication for Key Vault.
  * @class
- * @param {KeyVaultCredentials~authRequest} authenticator  A callback that receives a challenge and returns an authentication token.
+ * @param {KeyVaultCredentials~authRequest} authenticator  A callback that receives a challenge and returns an authentication token, or credentials instance obtained from msrestazure.
  */
 function KeyVaultCredentials(authenticator) {
     this.challengeCache = [];
-    this.authenticator = authenticator;
+    if(authenticator instanceof Function) {
+        this.authenticator = authenticator;
+    } else if(authenticator.getToken) {
+        var creds = authenticator;
+        
+        this.authenticator = (challenge, callback) => {
+            // make sure we're getting a token for correct resource
+            // see https://github.com/Azure/azure-sdk-for-python/blob/master/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py#L165 for py equivalent
+            if(creds.environment.activeDirectoryResourceId != challenge.resource) {
+                // clone the credential's azure environment so we don't overwrite values in a common reference
+                creds.environment = Object.assign({}, creds.environment);
+                creds.environment.activeDirectoryResourceId = challenge.resource;
+            }
+            
+            creds.getToken( (err, tokenResponse) => {
+                if(err) {
+                    return callback(err, null);
+                }
+                
+                return callback(null, tokenResponse.tokenType + ' ' + tokenResponse.accessToken);
+            });
+        };
+    } else {
+        throw new Error("Must provide an ADAL callback or credentials obtained from msrestazure.");
+    }        
 }
 
 KeyVaultCredentials.prototype.signRequest = function (resource, callback) {

--- a/lib/services/keyVault/lib/keyvault.d.ts
+++ b/lib/services/keyVault/lib/keyvault.d.ts
@@ -13,10 +13,13 @@ export { Models };
 /**
  * An object that performs authentication for Key Vault.
  * @class
- * @param {KeyVaultCredentials~authRequest} authenticator  A callback that receives a challenge and returns an authentication token.
+ * @param {KeyVaultCredentials~authRequest} authenticator  A callback that receives a challenge and returns an authentication token, or a credentials object obtained from msrestazure.
  */
 export class KeyVaultCredentials implements msRest.ServiceClientCredentials {
-  constructor( authenticator:  (challenge: any, callback: any) => any );
+  // constructor( authenticator:  (challenge: any, callback: any) => any );
+  // constructor( authenticator: msRest.ServiceClientCredentials );
+  constructor( authenticator: any );  // pretty sure we need just one constructor for both situations due to implementation of TypeScript
+  
   signRequest(webResource: msRest.WebResource, callback: { (err: Error): void }): void;
 }
 


### PR DESCRIPTION
This is tested and works - but my issue with it is how loose it forces the TypeScript declaration of the constructor of KeyVaultCredentials. An alternative would be a two-param constructor with an optional second param containing either null or the SP credentials object, as Scott did in Python. Not sure what's cleaner.

Thoughts?