### PR TITLE
Use nodejs.output-folder autorest argument

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,7 +95,7 @@ function generateProject(projectObj, specRoot, autoRestVersion) {
   if (projectObj.batchGeneration) {
     cmd += `--nodejs-sdks-folder=${__dirname}/${outputDir} --package-name=${packageName} --nodejs --license-header=MICROSOFT_MIT_NO_VERSION`;
   } else {
-    cmd += `--output-folder=${__dirname}/${outputDir} --package-name=${packageName} --nodejs --license-header=MICROSOFT_MIT_NO_VERSION`;
+    cmd += `--nodejs.output-folder=${__dirname}/${outputDir} --package-name=${packageName} --nodejs --license-header=MICROSOFT_MIT_NO_VERSION`;
   }
 
   // if using azure template, pass in azure-arm argument. otherwise, get the generic template by not passing in anything.


### PR DESCRIPTION
After adding Swagger to SDK config to azure-rest-api-specs, we start getting new config settings like `output-folder: $(node-sdks-folder)/lib/services/keyVaultManagement/lib`. This breaks local regeneration with `gulp codegen` because there's no `node-sdks-folder` variable defined.

The solution for this could be to read the swagger_to_sdk_config.json and apply the autorest settings in `gulp codegen`. The path of least resistance, though, is just to specify `nodejs.output-folder` instead of `output-folder` in `gulpfile.js` so that our local output-folder setting binds tighter than the one retrieved from azure-rest-api-specs. This seems less likely to break projects in gulp codegen, so that's what I'm doing for now.
