### PR TITLE
[AutoPR servicebus/resource-manager] ServiceBus: removed 'enableSubscriptionPartitioning' deprecated property from old API versions

### DIFF
--- a/lib/services/serviceBusManagement2/lib/models/index.d.ts
+++ b/lib/services/serviceBusManagement2/lib/models/index.d.ts
@@ -282,6 +282,8 @@ export interface MessageCountDetails {
  * messaging entity. Possible values include: 'Active', 'Disabled',
  * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
  * 'Renaming', 'Unknown'
+ * @member {boolean} [enableBatchedOperations] Value that indicates whether
+ * server-side batched operations are enabled.
  * @member {moment.duration} [autoDeleteOnIdle] ISO 8061 timeSpan idle interval
  * after which the queue is automatically deleted. The minimum duration is 5
  * minutes.
@@ -310,6 +312,7 @@ export interface SBQueue extends Resource {
   duplicateDetectionHistoryTimeWindow?: moment.Duration;
   maxDeliveryCount?: number;
   status?: string;
+  enableBatchedOperations?: boolean;
   autoDeleteOnIdle?: moment.Duration;
   enablePartitioning?: boolean;
   enableExpress?: boolean;

--- a/lib/services/serviceBusManagement2/lib/models/sBQueue.js
+++ b/lib/services/serviceBusManagement2/lib/models/sBQueue.js
@@ -66,6 +66,8 @@ class SBQueue extends models['Resource'] {
    * a messaging entity. Possible values include: 'Active', 'Disabled',
    * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
    * 'Renaming', 'Unknown'
+   * @member {boolean} [enableBatchedOperations] Value that indicates whether
+   * server-side batched operations are enabled.
    * @member {moment.duration} [autoDeleteOnIdle] ISO 8061 timeSpan idle
    * interval after which the queue is automatically deleted. The minimum
    * duration is 5 minutes.
@@ -231,6 +233,13 @@ class SBQueue extends models['Resource'] {
             type: {
               name: 'Enum',
               allowedValues: [ 'Active', 'Disabled', 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting', 'Renaming', 'Unknown' ]
+            }
+          },
+          enableBatchedOperations: {
+            required: false,
+            serializedName: 'properties.enableBatchedOperations',
+            type: {
+              name: 'Boolean'
             }
           },
           autoDeleteOnIdle: {

--- a/lib/services/serviceBusManagement2/lib/operations/index.d.ts
+++ b/lib/services/serviceBusManagement2/lib/operations/index.d.ts
@@ -2323,6 +2323,9 @@ export interface Queues {
      * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
      * 'Renaming', 'Unknown'
      *
+     * @param {boolean} [parameters.enableBatchedOperations] Value that indicates
+     * whether server-side batched operations are enabled.
+     *
      * @param {moment.duration} [parameters.autoDeleteOnIdle] ISO 8061 timeSpan
      * idle interval after which the queue is automatically deleted. The minimum
      * duration is 5 minutes.
@@ -2401,6 +2404,9 @@ export interface Queues {
      * status of a messaging entity. Possible values include: 'Active', 'Disabled',
      * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
      * 'Renaming', 'Unknown'
+     *
+     * @param {boolean} [parameters.enableBatchedOperations] Value that indicates
+     * whether server-side batched operations are enabled.
      *
      * @param {moment.duration} [parameters.autoDeleteOnIdle] ISO 8061 timeSpan
      * idle interval after which the queue is automatically deleted. The minimum

--- a/lib/services/serviceBusManagement2/lib/operations/queues.js
+++ b/lib/services/serviceBusManagement2/lib/operations/queues.js
@@ -231,6 +231,9 @@ function _listByNamespace(resourceGroupName, namespaceName, options, callback) {
  * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
  * 'Renaming', 'Unknown'
  *
+ * @param {boolean} [parameters.enableBatchedOperations] Value that indicates
+ * whether server-side batched operations are enabled.
+ *
  * @param {moment.duration} [parameters.autoDeleteOnIdle] ISO 8061 timeSpan
  * idle interval after which the queue is automatically deleted. The minimum
  * duration is 5 minutes.
@@ -2374,6 +2377,9 @@ class Queues {
    * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
    * 'Renaming', 'Unknown'
    *
+   * @param {boolean} [parameters.enableBatchedOperations] Value that indicates
+   * whether server-side batched operations are enabled.
+   *
    * @param {moment.duration} [parameters.autoDeleteOnIdle] ISO 8061 timeSpan
    * idle interval after which the queue is automatically deleted. The minimum
    * duration is 5 minutes.
@@ -2464,6 +2470,9 @@ class Queues {
    * status of a messaging entity. Possible values include: 'Active', 'Disabled',
    * 'Restoring', 'SendDisabled', 'ReceiveDisabled', 'Creating', 'Deleting',
    * 'Renaming', 'Unknown'
+   *
+   * @param {boolean} [parameters.enableBatchedOperations] Value that indicates
+   * whether server-side batched operations are enabled.
    *
    * @param {moment.duration} [parameters.autoDeleteOnIdle] ISO 8061 timeSpan
    * idle interval after which the queue is automatically deleted. The minimum

--- a/lib/services/serviceBusManagement2/lib/serviceBusManagementClient.d.ts
+++ b/lib/services/serviceBusManagement2/lib/serviceBusManagementClient.d.ts
@@ -10,9 +10,10 @@
 
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureServiceClient, AzureServiceClientOptions } from 'ms-rest-azure';
+import * as models from "./models";
 import * as operations from "./operations";
 
-declare class ServiceBusManagementClient extends AzureServiceClient {
+export default class ServiceBusManagementClient extends AzureServiceClient {
   /**
    * Initializes a new instance of the ServiceBusManagementClient class.
    * @constructor
@@ -67,4 +68,4 @@ declare class ServiceBusManagementClient extends AzureServiceClient {
   eventHubs: operations.EventHubs;
 }
 
-export = ServiceBusManagementClient;
+export { ServiceBusManagementClient, models as ServiceBusManagementModels };

--- a/lib/services/serviceBusManagement2/lib/serviceBusManagementClient.js
+++ b/lib/services/serviceBusManagement2/lib/serviceBusManagementClient.js
@@ -89,3 +89,6 @@ class ServiceBusManagementClient extends ServiceClient {
 }
 
 module.exports = ServiceBusManagementClient;
+module.exports['default'] = ServiceBusManagementClient;
+module.exports.ServiceBusManagementClient = ServiceBusManagementClient;
+module.exports.ServiceBusManagementModels = models;


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2733