### PR TITLE
Add codegen_mappings schema file and small gulpfile tweak

### DIFF
--- a/codegen_mappings.json
+++ b/codegen_mappings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./codegen_mappings.schema.json",
   "advisor": {
     "resource-manager": {
       "packageName": "azure-arm-advisor",
@@ -671,6 +672,8 @@
   "datacatalog": {
     "resource-manager": {
       "packageName": "azure-arm-datacatalog",
+      "packageVersion": "1.0.0-preview",
+      "generateMetadata": true,
       "dir": "datacatalogManagement/lib",
       "source": "datacatalog/resource-manager/readme.md"
     }

--- a/codegen_mappings.schema.json
+++ b/codegen_mappings.schema.json
@@ -1,0 +1,167 @@
+{
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": {
+        "description": "An Azure service.",
+        "type": "object",
+        "properties": {
+            "resource-manager": {
+                "$ref": "#definitions/resourceManagerPackageContainer"
+            },
+            "data-plane": {
+                "$ref": "#definitions/dataplanePackageContainer"
+            }
+        },
+        "additionalProperties": false
+    },
+    "definitions": {
+        "packageName": {
+            "description": "The name of the package that will be published to NPM.",
+            "type": "string",
+            "minLength": 1
+        },
+        "packageVersion": {
+            "description": "The version of the package that will be published to NPM.",
+            "type": "string",
+            "minLength": 1
+        },
+        "dir": {
+            "description": "The path where this package's generated files will be placed relative to azure-sdk-for-node/lib/services/.",
+            "type": "string",
+            "minLength": 1
+        },
+        "source": {
+            "description": "The path to the readme.md file relative to azure-rest-api-specs/specification/.",
+            "type": "string",
+            "minLength": 1
+        },
+        "clientName": {
+            "description": "The name of the client class that will be generated for this package.",
+            "type": "string",
+            "minLength": 1
+        },
+        "ft": {
+            "description": "The payload-flattening-threshold property that will be used when generating this package's files.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "language": {
+            "description": "The language that this package will target.",
+            "enum": [
+                "NodeJS",
+                "Azure.NodeJS"
+            ]
+        },
+        "tag": {
+            "description": "A tag that will be added to the AutoRest command line arguments.",
+            "type": "string",
+            "minLength": 1
+        },
+        "generateMetadata": {
+            "description": "Whether or not the package's package.json and readme.md files will be generated.",
+            "type": "boolean"
+        },
+        "resourceManagerPackageContainer": {
+            "oneOf":[
+                {
+                    "$ref": "#definitions/resourceManagerPackage"
+                },
+                {
+                    "description": "A collection of management packages for this service.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#definitions/resourceManagerPackage"
+                    }
+                }
+            ]
+        },
+        "resourceManagerPackage": {
+            "description": "The management package for this service.",
+            "type": "object",
+            "properties": {
+                "packageName": {
+                    "$ref": "#definitions/packageName"
+                },
+                "packageVersion": {
+                    "$ref": "#definitions/packageVersion"
+                },
+                "dir": {
+                    "$ref": "#definitions/dir"
+                },
+                "source": {
+                    "$ref": "#definitions/source"
+                },
+                "clientName": {
+                    "$ref": "#definitions/clientName"
+                },
+                "ft": {
+                    "$ref": "#definitions/ft"
+                },
+                "language": {
+                    "$ref": "#definitions/language"
+                },
+                "tag": {
+                    "$ref": "#definitions/tag"
+                },
+                "generateMetadata": {
+                    "$ref": "#definitions/generateMetadata"
+                }
+            },
+            "required": ["packageName", "dir", "source"],
+            "additionalProperties": false
+        },
+        "dataplanePackageContainer": {
+            "oneOf":[
+                {
+                    "$ref": "#definitions/dataplanePackage"
+                },
+                {
+                    "description": "A collection of dataplane packages for this service.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#definitions/dataplanePackage"
+                    }
+                }
+            ]
+        },
+        "dataplanePackage": {
+            "description": "The dataplane package for this service.",
+            "type": "object",
+            "properties": {
+                "packageName": {
+                    "$ref": "#definitions/packageName"
+                },
+                "packageVersion": {
+                    "$ref": "#definitions/packageVersion"
+                },
+                "dir": {
+                    "$ref": "#definitions/dir"
+                },
+                "source": {
+                    "$ref": "#definitions/source"
+                },
+                "clientName": {
+                    "$ref": "#definitions/clientName"
+                },
+                "ft": {
+                    "$ref": "#definitions/ft"
+                },
+                "language": {
+                    "$ref": "#definitions/language"
+                },
+                "tag": {
+                    "$ref": "#definitions/tag"
+                },
+                "generateMetadata": {
+                    "$ref": "#definitions/generateMetadata"
+                }
+            },
+            "required": ["packageName", "dir", "source"],
+            "additionalProperties": false
+        }
+    }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,6 @@ const specRoot = args['spec-root'] || "https://raw.githubusercontent.com/Azure/a
 const project = args['project'];
 const use = args['use'];
 const generateMetadata = args['generate-metadata'];
-var language = 'Azure.NodeJS';
 var modeler = 'Swagger';
 const regexForExcludedServices = /\/(intune|documentdbManagement|insightsManagement|insights|search)\//i;
 
@@ -84,7 +83,7 @@ function generateProject(projectObj, specRoot, autoRestVersion) {
   let isInputJson = projectObj.source.endsWith("json");
   let result;
   const azureTemplate = 'Azure.NodeJs';
-  language = azureTemplate;
+  let language = azureTemplate;
   //servicefabric wants to generate using generic NodeJS.
   if (projectObj.language && projectObj.language.match(/^NodeJS$/ig) !== null) {
     language = projectObj.language;


### PR DESCRIPTION
Adding a JSON schema for codegen_mappings.json doesn't add any functionality, but it does add editor IntelliSense and descriptions. The descriptions are always a good reminder for what a property is used for.
If we add more properties to each of the package objects within codegen_mappings.json, a schema is a great way to ensure that you didn't forget to add required properties to any packages.