### PR TITLE
[AutoPR monitor/resource-manager] fix documentation bug: max length of Group Short Name should be 12

### DIFF
--- a/lib/services/monitorManagement/lib/models/actionGroupResource.js
+++ b/lib/services/monitorManagement/lib/models/actionGroupResource.js
@@ -111,7 +111,7 @@ class ActionGroupResource extends models['Resource'] {
             required: true,
             serializedName: 'properties.groupShortName',
             constraints: {
-              MaxLength: 15
+              MaxLength: 12
             },
             type: {
               name: 'String'


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2841