### PR TITLE
[AutoPR cognitiveservices/data-plane/ContentModerator] Set language parameter as a non-required field for Screen Text API

### DIFF
--- a/lib/services/contentModerator/lib/operations/index.d.ts
+++ b/lib/services/contentModerator/lib/operations/index.d.ts
@@ -921,14 +921,14 @@ export interface TextModeration {
      * Detects profanity in more than 100 languages and match against custom and
      * shared blacklists.
      *
-     * @param {string} language Language of the terms.
-     *
      * @param {string} textContentType The content type. Possible values include:
      * 'text/plain', 'text/html', 'text/xml', 'text/markdown'
      *
      * @param {object} textContent Content to screen.
      *
      * @param {object} [options] Optional Parameters.
+     *
+     * @param {string} [options.language] Language of the text.
      *
      * @param {boolean} [options.autocorrect] Autocorrect text.
      *
@@ -947,7 +947,7 @@ export interface TextModeration {
      *
      * @reject {Error|ServiceError} - The error object.
      */
-    screenTextWithHttpOperationResponse(language: string, textContentType: string, textContent: stream.Readable, options?: { autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }): Promise<HttpOperationResponse<models.Screen>>;
+    screenTextWithHttpOperationResponse(textContentType: string, textContent: stream.Readable, options?: { language? : string, autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }): Promise<HttpOperationResponse<models.Screen>>;
 
     /**
      * @summary Detect profanity and match against custom and shared blacklists
@@ -955,14 +955,14 @@ export interface TextModeration {
      * Detects profanity in more than 100 languages and match against custom and
      * shared blacklists.
      *
-     * @param {string} language Language of the terms.
-     *
      * @param {string} textContentType The content type. Possible values include:
      * 'text/plain', 'text/html', 'text/xml', 'text/markdown'
      *
      * @param {object} textContent Content to screen.
      *
      * @param {object} [options] Optional Parameters.
+     *
+     * @param {string} [options.language] Language of the text.
      *
      * @param {boolean} [options.autocorrect] Autocorrect text.
      *
@@ -997,9 +997,9 @@ export interface TextModeration {
      *
      *                      {http.IncomingMessage} [response] - The HTTP Response stream if an error did not occur.
      */
-    screenText(language: string, textContentType: string, textContent: stream.Readable, options?: { autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }): Promise<models.Screen>;
-    screenText(language: string, textContentType: string, textContent: stream.Readable, callback: ServiceCallback<models.Screen>): void;
-    screenText(language: string, textContentType: string, textContent: stream.Readable, options: { autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<models.Screen>): void;
+    screenText(textContentType: string, textContent: stream.Readable, options?: { language? : string, autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }): Promise<models.Screen>;
+    screenText(textContentType: string, textContent: stream.Readable, callback: ServiceCallback<models.Screen>): void;
+    screenText(textContentType: string, textContent: stream.Readable, options: { language? : string, autocorrect? : boolean, pII? : boolean, listId? : string, classify? : boolean, customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<models.Screen>): void;
 
 
     /**

--- a/lib/services/contentModerator/lib/operations/textModeration.js
+++ b/lib/services/contentModerator/lib/operations/textModeration.js
@@ -19,14 +19,14 @@ const WebResource = msRest.WebResource;
  * Detects profanity in more than 100 languages and match against custom and
  * shared blacklists.
  *
- * @param {string} language Language of the terms.
- *
  * @param {string} textContentType The content type. Possible values include:
  * 'text/plain', 'text/html', 'text/xml', 'text/markdown'
  *
  * @param {object} textContent Content to screen.
  *
  * @param {object} [options] Optional Parameters.
+ *
+ * @param {string} [options.language] Language of the text.
  *
  * @param {boolean} [options.autocorrect] Autocorrect text.
  *
@@ -52,7 +52,7 @@ const WebResource = msRest.WebResource;
  *
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
-function _screenText(language, textContentType, textContent, options, callback) {
+function _screenText(textContentType, textContent, options, callback) {
    /* jshint validthis: true */
   let client = this.client;
   if(!callback && typeof options === 'function') {
@@ -62,6 +62,7 @@ function _screenText(language, textContentType, textContent, options, callback) 
   if (!callback) {
     throw new Error('callback cannot be null.');
   }
+  let language = (options && options.language !== undefined) ? options.language : undefined;
   let autocorrect = (options && options.autocorrect !== undefined) ? options.autocorrect : false;
   let pII = (options && options.pII !== undefined) ? options.pII : false;
   let listId = (options && options.listId !== undefined) ? options.listId : undefined;
@@ -71,8 +72,8 @@ function _screenText(language, textContentType, textContent, options, callback) 
     if (this.client.baseUrl === null || this.client.baseUrl === undefined || typeof this.client.baseUrl.valueOf() !== 'string') {
       throw new Error('this.client.baseUrl cannot be null or undefined and it must be of type string.');
     }
-    if (language === null || language === undefined || typeof language.valueOf() !== 'string') {
-      throw new Error('language cannot be null or undefined and it must be of type string.');
+    if (language !== null && language !== undefined && typeof language.valueOf() !== 'string') {
+      throw new Error('language must be of type string.');
     }
     if (autocorrect !== null && autocorrect !== undefined && typeof autocorrect !== 'boolean') {
       throw new Error('autocorrect must be of type boolean.');
@@ -101,7 +102,9 @@ function _screenText(language, textContentType, textContent, options, callback) 
   let requestUrl = baseUrl + (baseUrl.endsWith('/') ? '' : '/') + 'contentmoderator/moderate/v1.0/ProcessText/Screen/';
   requestUrl = requestUrl.replace('{baseUrl}', this.client.baseUrl);
   let queryParameters = [];
-  queryParameters.push('language=' + encodeURIComponent(language));
+  if (language !== null && language !== undefined) {
+    queryParameters.push('language=' + encodeURIComponent(language));
+  }
   if (autocorrect !== null && autocorrect !== undefined) {
     queryParameters.push('autocorrect=' + encodeURIComponent(autocorrect.toString()));
   }
@@ -349,14 +352,14 @@ class TextModeration {
    * Detects profanity in more than 100 languages and match against custom and
    * shared blacklists.
    *
-   * @param {string} language Language of the terms.
-   *
    * @param {string} textContentType The content type. Possible values include:
    * 'text/plain', 'text/html', 'text/xml', 'text/markdown'
    *
    * @param {object} textContent Content to screen.
    *
    * @param {object} [options] Optional Parameters.
+   *
+   * @param {string} [options.language] Language of the text.
    *
    * @param {boolean} [options.autocorrect] Autocorrect text.
    *
@@ -375,11 +378,11 @@ class TextModeration {
    *
    * @reject {Error} - The error object.
    */
-  screenTextWithHttpOperationResponse(language, textContentType, textContent, options) {
+  screenTextWithHttpOperationResponse(textContentType, textContent, options) {
     let client = this.client;
     let self = this;
     return new Promise((resolve, reject) => {
-      self._screenText(language, textContentType, textContent, options, (err, result, request, response) => {
+      self._screenText(textContentType, textContent, options, (err, result, request, response) => {
         let httpOperationResponse = new msRest.HttpOperationResponse(request, response);
         httpOperationResponse.body = result;
         if (err) { reject(err); }
@@ -395,14 +398,14 @@ class TextModeration {
    * Detects profanity in more than 100 languages and match against custom and
    * shared blacklists.
    *
-   * @param {string} language Language of the terms.
-   *
    * @param {string} textContentType The content type. Possible values include:
    * 'text/plain', 'text/html', 'text/xml', 'text/markdown'
    *
    * @param {object} textContent Content to screen.
    *
    * @param {object} [options] Optional Parameters.
+   *
+   * @param {string} [options.language] Language of the text.
    *
    * @param {boolean} [options.autocorrect] Autocorrect text.
    *
@@ -437,7 +440,7 @@ class TextModeration {
    *
    *                      {stream} [response] - The HTTP Response stream if an error did not occur.
    */
-  screenText(language, textContentType, textContent, options, optionalCallback) {
+  screenText(textContentType, textContent, options, optionalCallback) {
     let client = this.client;
     let self = this;
     if (!optionalCallback && typeof options === 'function') {
@@ -446,14 +449,14 @@ class TextModeration {
     }
     if (!optionalCallback) {
       return new Promise((resolve, reject) => {
-        self._screenText(language, textContentType, textContent, options, (err, result, request, response) => {
+        self._screenText(textContentType, textContent, options, (err, result, request, response) => {
           if (err) { reject(err); }
           else { resolve(result); }
           return;
         });
       });
     } else {
-      return self._screenText(language, textContentType, textContent, options, optionalCallback);
+      return self._screenText(textContentType, textContent, options, optionalCallback);
     }
   }
 


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2884