### PR TITLE
[AutoPR network/resource-manager] [Microsoft.Network] Make id read-only for DdosProtectionPlan by bringing properties from shared resource (Fix RPCViolation)

### DIFF
--- a/lib/services/networkManagement2/lib/models/ddosProtectionPlan.js
+++ b/lib/services/networkManagement2/lib/models/ddosProtectionPlan.js
@@ -15,11 +15,16 @@ const models = require('./index');
 /**
  * A DDoS protection plan in a resource group.
  *
- * @extends models['Resource']
+ * @extends models['BaseResource']
  */
-class DdosProtectionPlan extends models['Resource'] {
+class DdosProtectionPlan extends models['BaseResource'] {
   /**
    * Create a DdosProtectionPlan.
+   * @member {string} [id] Resource ID.
+   * @member {string} [name] Resource name.
+   * @member {string} [type] Resource type.
+   * @member {string} [location] Resource location.
+   * @member {object} [tags] Resource tags.
    * @member {string} [resourceGuid] The resource GUID property of the DDoS
    * protection plan resource. It uniquely identifies the resource, even if the
    * user changes its name or migrate the resource across subscriptions or
@@ -52,6 +57,7 @@ class DdosProtectionPlan extends models['Resource'] {
         modelProperties: {
           id: {
             required: false,
+            readOnly: true,
             serializedName: 'id',
             type: {
               name: 'String'

--- a/lib/services/networkManagement2/lib/models/expressRouteCrossConnection.js
+++ b/lib/services/networkManagement2/lib/models/expressRouteCrossConnection.js
@@ -130,7 +130,6 @@ class ExpressRouteCrossConnection extends models['Resource'] {
           },
           peeringLocation: {
             required: false,
-            readOnly: true,
             serializedName: 'properties.peeringLocation',
             type: {
               name: 'String'
@@ -138,7 +137,6 @@ class ExpressRouteCrossConnection extends models['Resource'] {
           },
           bandwidthInMbps: {
             required: false,
-            readOnly: true,
             serializedName: 'properties.bandwidthInMbps',
             type: {
               name: 'Number'
@@ -146,7 +144,6 @@ class ExpressRouteCrossConnection extends models['Resource'] {
           },
           expressRouteCircuit: {
             required: false,
-            readOnly: true,
             serializedName: 'properties.expressRouteCircuit',
             type: {
               name: 'Composite',

--- a/lib/services/networkManagement2/lib/models/expressRouteCrossConnectionPeering.js
+++ b/lib/services/networkManagement2/lib/models/expressRouteCrossConnectionPeering.js
@@ -221,7 +221,6 @@ class ExpressRouteCrossConnectionPeering extends models['SubResource'] {
           },
           gatewayManagerEtag: {
             required: false,
-            readOnly: true,
             serializedName: 'properties.gatewayManagerEtag',
             type: {
               name: 'String'

--- a/lib/services/networkManagement2/lib/models/index.d.ts
+++ b/lib/services/networkManagement2/lib/models/index.d.ts
@@ -2432,6 +2432,11 @@ export interface DnsNameAvailabilityResult {
  * @constructor
  * A DDoS protection plan in a resource group.
  *
+ * @member {string} [id] Resource ID.
+ * @member {string} [name] Resource name.
+ * @member {string} [type] Resource type.
+ * @member {string} [location] Resource location.
+ * @member {object} [tags] Resource tags.
  * @member {string} [resourceGuid] The resource GUID property of the DDoS
  * protection plan resource. It uniquely identifies the resource, even if the
  * user changes its name or migrate the resource across subscriptions or
@@ -2444,7 +2449,12 @@ export interface DnsNameAvailabilityResult {
  * @member {string} [etag] A unique read-only string that changes whenever the
  * resource is updated.
  */
-export interface DdosProtectionPlan extends Resource {
+export interface DdosProtectionPlan extends BaseResource {
+  readonly id?: string;
+  readonly name?: string;
+  readonly type?: string;
+  location?: string;
+  tags?: { [propertyName: string]: string };
   readonly resourceGuid?: string;
   readonly provisioningState?: string;
   readonly virtualNetworks?: SubResource[];
@@ -3164,7 +3174,7 @@ export interface ExpressRouteCrossConnectionPeering extends SubResource {
   vlanId?: number;
   microsoftPeeringConfig?: ExpressRouteCircuitPeeringConfig;
   readonly provisioningState?: string;
-  readonly gatewayManagerEtag?: string;
+  gatewayManagerEtag?: string;
   lastModifiedBy?: string;
   ipv6PeeringConfig?: Ipv6ExpressRouteCircuitPeeringConfig;
   name?: string;
@@ -3203,9 +3213,9 @@ export interface ExpressRouteCrossConnection extends Resource {
   readonly primaryAzurePort?: string;
   readonly secondaryAzurePort?: string;
   readonly sTag?: number;
-  readonly peeringLocation?: string;
-  readonly bandwidthInMbps?: number;
-  readonly expressRouteCircuit?: ExpressRouteCircuitReference;
+  peeringLocation?: string;
+  bandwidthInMbps?: number;
+  expressRouteCircuit?: ExpressRouteCircuitReference;
   serviceProviderProvisioningState?: string;
   serviceProviderNotes?: string;
   readonly provisioningState?: string;

--- a/lib/services/networkManagement2/lib/operations/ddosProtectionPlans.js
+++ b/lib/services/networkManagement2/lib/operations/ddosProtectionPlans.js
@@ -231,8 +231,6 @@ function _get(resourceGroupName, ddosProtectionPlanName, options, callback) {
  * @param {object} parameters Parameters supplied to the create or update
  * operation.
  *
- * @param {string} [parameters.id] Resource ID.
- *
  * @param {string} [parameters.location] Resource location.
  *
  * @param {object} [parameters.tags] Resource tags.
@@ -711,8 +709,6 @@ function _beginDeleteMethod(resourceGroupName, ddosProtectionPlanName, options, 
  *
  * @param {object} parameters Parameters supplied to the create or update
  * operation.
- *
- * @param {string} [parameters.id] Resource ID.
  *
  * @param {string} [parameters.location] Resource location.
  *
@@ -1344,8 +1340,6 @@ class DdosProtectionPlans {
    * @param {object} parameters Parameters supplied to the create or update
    * operation.
    *
-   * @param {string} [parameters.id] Resource ID.
-   *
    * @param {string} [parameters.location] Resource location.
    *
    * @param {object} [parameters.tags] Resource tags.
@@ -1384,8 +1378,6 @@ class DdosProtectionPlans {
    *
    * @param {object} parameters Parameters supplied to the create or update
    * operation.
-   *
-   * @param {string} [parameters.id] Resource ID.
    *
    * @param {string} [parameters.location] Resource location.
    *
@@ -1695,8 +1687,6 @@ class DdosProtectionPlans {
    * @param {object} parameters Parameters supplied to the create or update
    * operation.
    *
-   * @param {string} [parameters.id] Resource ID.
-   *
    * @param {string} [parameters.location] Resource location.
    *
    * @param {object} [parameters.tags] Resource tags.
@@ -1735,8 +1725,6 @@ class DdosProtectionPlans {
    *
    * @param {object} parameters Parameters supplied to the create or update
    * operation.
-   *
-   * @param {string} [parameters.id] Resource ID.
    *
    * @param {string} [parameters.location] Resource location.
    *

--- a/lib/services/networkManagement2/lib/operations/expressRouteCrossConnectionPeerings.js
+++ b/lib/services/networkManagement2/lib/operations/expressRouteCrossConnectionPeerings.js
@@ -412,6 +412,9 @@ function _get(resourceGroupName, crossConnectionName, peeringName, options, call
  * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
  * peering configuration.
  *
+ * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+ * Etag.
+ *
  * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
  * or the customer last modified the peering.
  *
@@ -721,6 +724,9 @@ function _beginDeleteMethod(resourceGroupName, crossConnectionName, peeringName,
  *
  * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
  * peering configuration.
+ *
+ * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+ * Etag.
  *
  * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
  * or the customer last modified the peering.
@@ -1422,6 +1428,9 @@ class ExpressRouteCrossConnectionPeerings {
    * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
    * peering configuration.
    *
+   * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+   * Etag.
+   *
    * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
    * or the customer last modified the peering.
    *
@@ -1553,6 +1562,9 @@ class ExpressRouteCrossConnectionPeerings {
    *
    * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
    * peering configuration.
+   *
+   * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+   * Etag.
    *
    * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
    * or the customer last modified the peering.
@@ -1800,6 +1812,9 @@ class ExpressRouteCrossConnectionPeerings {
    * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
    * peering configuration.
    *
+   * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+   * Etag.
+   *
    * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
    * or the customer last modified the peering.
    *
@@ -1931,6 +1946,9 @@ class ExpressRouteCrossConnectionPeerings {
    *
    * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
    * peering configuration.
+   *
+   * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+   * Etag.
    *
    * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
    * or the customer last modified the peering.

--- a/lib/services/networkManagement2/lib/operations/expressRouteCrossConnections.js
+++ b/lib/services/networkManagement2/lib/operations/expressRouteCrossConnections.js
@@ -442,6 +442,16 @@ function _get(resourceGroupName, crossConnectionName, options, callback) {
  * @param {object} parameters Parameters supplied to the update express route
  * crossConnection operation.
  *
+ * @param {string} [parameters.peeringLocation] The peering location of the
+ * ExpressRoute circuit.
+ *
+ * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+ *
+ * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+ *
+ * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+ * Route Circuit Id.
+ *
  * @param {string} [parameters.serviceProviderProvisioningState] The
  * provisioning state of the circuit in the connectivity provider system.
  * Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned'.
@@ -880,6 +890,16 @@ function _listRoutesTable(resourceGroupName, crossConnectionName, peeringName, d
  *
  * @param {object} parameters Parameters supplied to the update express route
  * crossConnection operation.
+ *
+ * @param {string} [parameters.peeringLocation] The peering location of the
+ * ExpressRoute circuit.
+ *
+ * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+ *
+ * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+ *
+ * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+ * Route Circuit Id.
  *
  * @param {string} [parameters.serviceProviderProvisioningState] The
  * provisioning state of the circuit in the connectivity provider system.
@@ -2238,6 +2258,16 @@ class ExpressRouteCrossConnections {
    * @param {object} parameters Parameters supplied to the update express route
    * crossConnection operation.
    *
+   * @param {string} [parameters.peeringLocation] The peering location of the
+   * ExpressRoute circuit.
+   *
+   * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+   *
+   * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+   *
+   * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+   * Route Circuit Id.
+   *
    * @param {string} [parameters.serviceProviderProvisioningState] The
    * provisioning state of the circuit in the connectivity provider system.
    * Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned'.
@@ -2290,6 +2320,16 @@ class ExpressRouteCrossConnections {
    *
    * @param {object} parameters Parameters supplied to the update express route
    * crossConnection operation.
+   *
+   * @param {string} [parameters.peeringLocation] The peering location of the
+   * ExpressRoute circuit.
+   *
+   * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+   *
+   * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+   *
+   * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+   * Route Circuit Id.
    *
    * @param {string} [parameters.serviceProviderProvisioningState] The
    * provisioning state of the circuit in the connectivity provider system.
@@ -2762,6 +2802,16 @@ class ExpressRouteCrossConnections {
    * @param {object} parameters Parameters supplied to the update express route
    * crossConnection operation.
    *
+   * @param {string} [parameters.peeringLocation] The peering location of the
+   * ExpressRoute circuit.
+   *
+   * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+   *
+   * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+   *
+   * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+   * Route Circuit Id.
+   *
    * @param {string} [parameters.serviceProviderProvisioningState] The
    * provisioning state of the circuit in the connectivity provider system.
    * Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned'.
@@ -2814,6 +2864,16 @@ class ExpressRouteCrossConnections {
    *
    * @param {object} parameters Parameters supplied to the update express route
    * crossConnection operation.
+   *
+   * @param {string} [parameters.peeringLocation] The peering location of the
+   * ExpressRoute circuit.
+   *
+   * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+   *
+   * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+   *
+   * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+   * Route Circuit Id.
    *
    * @param {string} [parameters.serviceProviderProvisioningState] The
    * provisioning state of the circuit in the connectivity provider system.

--- a/lib/services/networkManagement2/lib/operations/index.d.ts
+++ b/lib/services/networkManagement2/lib/operations/index.d.ts
@@ -2508,8 +2508,6 @@ export interface DdosProtectionPlans {
      * @param {object} parameters Parameters supplied to the create or update
      * operation.
      *
-     * @param {string} [parameters.id] Resource ID.
-     *
      * @param {string} [parameters.location] Resource location.
      *
      * @param {object} [parameters.tags] Resource tags.
@@ -2536,8 +2534,6 @@ export interface DdosProtectionPlans {
      *
      * @param {object} parameters Parameters supplied to the create or update
      * operation.
-     *
-     * @param {string} [parameters.id] Resource ID.
      *
      * @param {string} [parameters.location] Resource location.
      *
@@ -2751,8 +2747,6 @@ export interface DdosProtectionPlans {
      * @param {object} parameters Parameters supplied to the create or update
      * operation.
      *
-     * @param {string} [parameters.id] Resource ID.
-     *
      * @param {string} [parameters.location] Resource location.
      *
      * @param {object} [parameters.tags] Resource tags.
@@ -2779,8 +2773,6 @@ export interface DdosProtectionPlans {
      *
      * @param {object} parameters Parameters supplied to the create or update
      * operation.
-     *
-     * @param {string} [parameters.id] Resource ID.
      *
      * @param {string} [parameters.location] Resource location.
      *
@@ -6781,6 +6773,16 @@ export interface ExpressRouteCrossConnections {
      * @param {object} parameters Parameters supplied to the update express route
      * crossConnection operation.
      *
+     * @param {string} [parameters.peeringLocation] The peering location of the
+     * ExpressRoute circuit.
+     *
+     * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+     *
+     * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+     *
+     * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+     * Route Circuit Id.
+     *
      * @param {string} [parameters.serviceProviderProvisioningState] The
      * provisioning state of the circuit in the connectivity provider system.
      * Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned'.
@@ -6821,6 +6823,16 @@ export interface ExpressRouteCrossConnections {
      *
      * @param {object} parameters Parameters supplied to the update express route
      * crossConnection operation.
+     *
+     * @param {string} [parameters.peeringLocation] The peering location of the
+     * ExpressRoute circuit.
+     *
+     * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+     *
+     * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+     *
+     * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+     * Route Circuit Id.
      *
      * @param {string} [parameters.serviceProviderProvisioningState] The
      * provisioning state of the circuit in the connectivity provider system.
@@ -7170,6 +7182,16 @@ export interface ExpressRouteCrossConnections {
      * @param {object} parameters Parameters supplied to the update express route
      * crossConnection operation.
      *
+     * @param {string} [parameters.peeringLocation] The peering location of the
+     * ExpressRoute circuit.
+     *
+     * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+     *
+     * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+     *
+     * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+     * Route Circuit Id.
+     *
      * @param {string} [parameters.serviceProviderProvisioningState] The
      * provisioning state of the circuit in the connectivity provider system.
      * Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned'.
@@ -7210,6 +7232,16 @@ export interface ExpressRouteCrossConnections {
      *
      * @param {object} parameters Parameters supplied to the update express route
      * crossConnection operation.
+     *
+     * @param {string} [parameters.peeringLocation] The peering location of the
+     * ExpressRoute circuit.
+     *
+     * @param {number} [parameters.bandwidthInMbps] The circuit bandwidth In Mbps.
+     *
+     * @param {object} [parameters.expressRouteCircuit] The ExpressRouteCircuit
+     *
+     * @param {string} [parameters.expressRouteCircuit.id] Corresponding Express
+     * Route Circuit Id.
      *
      * @param {string} [parameters.serviceProviderProvisioningState] The
      * provisioning state of the circuit in the connectivity provider system.
@@ -7900,6 +7932,9 @@ export interface ExpressRouteCrossConnectionPeerings {
      * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
      * peering configuration.
      *
+     * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+     * Etag.
+     *
      * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
      * or the customer last modified the peering.
      *
@@ -8019,6 +8054,9 @@ export interface ExpressRouteCrossConnectionPeerings {
      *
      * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
      * peering configuration.
+     *
+     * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+     * Etag.
      *
      * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
      * or the customer last modified the peering.
@@ -8224,6 +8262,9 @@ export interface ExpressRouteCrossConnectionPeerings {
      * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
      * peering configuration.
      *
+     * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+     * Etag.
+     *
      * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
      * or the customer last modified the peering.
      *
@@ -8343,6 +8384,9 @@ export interface ExpressRouteCrossConnectionPeerings {
      *
      * @param {object} [peeringParameters.microsoftPeeringConfig] The Microsoft
      * peering configuration.
+     *
+     * @param {string} [peeringParameters.gatewayManagerEtag] The GatewayManager
+     * Etag.
      *
      * @param {string} [peeringParameters.lastModifiedBy] Gets whether the provider
      * or the customer last modified the peering.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2901