### PR TITLE
[AutoPR eventgrid/resource-manager] Reverting back x-ms-azure-resource from TrackedResource definition as it is already part of the base class Resource.

### DIFF
--- a/lib/services/eventgridManagement/lib/models/index.d.ts
+++ b/lib/services/eventgridManagement/lib/models/index.d.ts
@@ -235,7 +235,7 @@ export interface Operation {
  * @member {string} location Location of the resource
  * @member {object} [tags] Tags of the resource
  */
-export interface TrackedResource extends BaseResource {
+export interface TrackedResource extends Resource {
   location: string;
   tags?: { [propertyName: string]: string };
 }

--- a/lib/services/eventgridManagement/lib/models/topic.js
+++ b/lib/services/eventgridManagement/lib/models/topic.js
@@ -43,6 +43,30 @@ class Topic extends models['TrackedResource'] {
         name: 'Composite',
         className: 'Topic',
         modelProperties: {
+          id: {
+            required: false,
+            readOnly: true,
+            serializedName: 'id',
+            type: {
+              name: 'String'
+            }
+          },
+          name: {
+            required: false,
+            readOnly: true,
+            serializedName: 'name',
+            type: {
+              name: 'String'
+            }
+          },
+          type: {
+            required: false,
+            readOnly: true,
+            serializedName: 'type',
+            type: {
+              name: 'String'
+            }
+          },
           location: {
             required: true,
             serializedName: 'location',

--- a/lib/services/eventgridManagement/lib/models/trackedResource.js
+++ b/lib/services/eventgridManagement/lib/models/trackedResource.js
@@ -15,9 +15,9 @@ const models = require('./index');
 /**
  * Definition of a Tracked Resource
  *
- * @extends models['BaseResource']
+ * @extends models['Resource']
  */
-class TrackedResource extends models['BaseResource'] {
+class TrackedResource extends models['Resource'] {
   /**
    * Create a TrackedResource.
    * @member {string} location Location of the resource
@@ -41,6 +41,30 @@ class TrackedResource extends models['BaseResource'] {
         name: 'Composite',
         className: 'TrackedResource',
         modelProperties: {
+          id: {
+            required: false,
+            readOnly: true,
+            serializedName: 'id',
+            type: {
+              name: 'String'
+            }
+          },
+          name: {
+            required: false,
+            readOnly: true,
+            serializedName: 'name',
+            type: {
+              name: 'String'
+            }
+          },
+          type: {
+            required: false,
+            readOnly: true,
+            serializedName: 'type',
+            type: {
+              name: 'String'
+            }
+          },
           location: {
             required: true,
             serializedName: 'location',


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2991