### PR TITLE
lib/credentials/msiVmTokenCredentials.js requires request

### DIFF
--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -29,7 +29,8 @@
     "uuid": "^3.2.1",
     "adal-node": "^0.1.27",
     "ms-rest": "^2.3.2",
-    "moment": "^2.20.1"
+    "moment": "^2.20.1",
+    "request": "^2.83.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",


### PR DESCRIPTION
request required without explicit listed in package.json.
which can cause issues with other buildtools
```
Error: Cannot find module 'request'

```