### PR TITLE
[AutoPR cognitiveservices/data-plane/ComputerVision] Add Spanish as an option as ServiceLanguage for ComputerVision

### DIFF
--- a/lib/services/computerVision/lib/computerVisionAPIClient.d.ts
+++ b/lib/services/computerVision/lib/computerVisionAPIClient.d.ts
@@ -127,9 +127,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -172,9 +172,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -397,9 +397,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -432,9 +432,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -481,9 +481,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -511,9 +511,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -563,9 +563,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -596,9 +596,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -786,9 +786,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -828,9 +828,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1053,9 +1053,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1088,9 +1088,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1137,9 +1137,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1167,9 +1167,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1219,9 +1219,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -1252,9 +1252,9 @@ export default class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request

--- a/lib/services/computerVision/lib/computerVisionAPIClient.js
+++ b/lib/services/computerVision/lib/computerVisionAPIClient.js
@@ -178,9 +178,9 @@ function _listModels(options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -742,9 +742,9 @@ function _recognizePrintedText(detectOrientation, url, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -919,9 +919,9 @@ function _describeImage(url, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -1092,9 +1092,9 @@ function _tagImage(url, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -1557,9 +1557,9 @@ function _getTextOperationResult(operationId, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -2063,9 +2063,9 @@ function _recognizePrintedTextInStream(detectOrientation, image, options, callba
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -2223,9 +2223,9 @@ function _describeImageInStream(image, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -2379,9 +2379,9 @@ function _tagImageInStream(image, options, callback) {
  *
  * @param {string} [options.language] The desired language for output
  * generation. If this parameter is not specified, the default value is
- * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
- * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
- * 'pt', 'zh'
+ * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+ * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+ * 'en', 'es', 'ja', 'pt', 'zh'
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -2817,9 +2817,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -2874,9 +2874,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3168,9 +3168,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3215,9 +3215,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3279,9 +3279,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3321,9 +3321,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3388,9 +3388,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3433,9 +3433,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3692,9 +3692,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -3746,9 +3746,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4040,9 +4040,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4087,9 +4087,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4151,9 +4151,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4193,9 +4193,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4260,9 +4260,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -4305,9 +4305,9 @@ class ComputerVisionAPIClient extends ServiceClient {
    *
    * @param {string} [options.language] The desired language for output
    * generation. If this parameter is not specified, the default value is
-   * &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese pt -
-   * Portuguese zh - Simplified Chinese. Possible values include: 'en', 'ja',
-   * 'pt', 'zh'
+   * &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja -
+   * Japanese, pt - Portuguese, zh - Simplified Chinese. Possible values include:
+   * 'en', 'es', 'ja', 'pt', 'zh'
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3222