### PR TITLE
Validate authority

### DIFF
--- a/runtime/ms-rest-azure/Changelog.md
+++ b/runtime/ms-rest-azure/Changelog.md
@@ -1,3 +1,9 @@
+### 2.5.7 (06/12/2018)
+- Added `validateAuthority` to AzureEnvironment type definitions
+
+### 2.5.6 (06/12/2018)
+- Updated vulnerable dependencies
+
 ### 2.5.5 (03/12/2018)
 - Added an `interface TokenResponse` that extends `adal.TokenResponse`. This interface would be the return type of `getToken()` method on the credential classes.
 - Added `getToken()` method on `DeviceTokenCredentials` to make it consistent with other credential classes.
@@ -21,7 +27,7 @@
 - Convert underscore_seperated properties in MSI tokenResponses to CamelCase.
 
 ### 2.4.5 (11/17/2017)
-- Added `innererror` field to `CloudError` class. #2328 
+- Added `innererror` field to `CloudError` class. #2328
 
 ### 2.4.4 (11/07/2017)
 - Fixed a bug in the request url creation for AppService MSI.
@@ -36,7 +42,7 @@
  - Added support for `MSIAppServiceTokenCredentials` and `loginWithAppServiceMSI()` #2292.
 
 ### 2.4.1 (10/11/2017)
-- Restricted dependency on "moment" from "^2.18.1" to "~2.18.1" due to bugs in 2.19.0 
+- Restricted dependency on "moment" from "^2.18.1" to "~2.18.1" due to bugs in 2.19.0
 
 ### 2.4.0 (10/03/2017)
 - Bug fix: Renamed `loginwithAuthFile` to `loginWithAuthFile`.
@@ -56,7 +62,7 @@
 
 ### 2.3.1 (09/11/2017)
 - Fixed endpoint information for Azure environments
-- Added typings for authfile and msi auth 
+- Added typings for authfile and msi auth
 
 ### 2.3.0 (08/25/2017)
 - Added support to authenticate using service principal from auth file. #2225

--- a/runtime/ms-rest-azure/index.d.ts
+++ b/runtime/ms-rest-azure/index.d.ts
@@ -297,7 +297,8 @@ export class AzureEnvironment {
     storageEndpointSuffix: '.core.windows.net',
     keyVaultDnsSuffix: '.vault.azure.net',
     azureDataLakeStoreFileSystemEndpointSuffix: 'azuredatalakestore.net',
-    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'azuredatalakeanalytics.net'
+    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'azuredatalakeanalytics.net',
+    validateAuthority: true
   };
 
   static readonly AzureChina: {
@@ -318,7 +319,8 @@ export class AzureEnvironment {
     keyVaultDnsSuffix: '.vault.azure.cn',
     // TODO: add dns suffixes for the china cloud for datalake store and datalake analytics once they are defined.
     azureDataLakeStoreFileSystemEndpointSuffix: 'N/A',
-    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A'
+    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A',
+    validateAuthority: true
   };
 
   static readonly AzureUSGovernment: {
@@ -338,7 +340,8 @@ export class AzureEnvironment {
     storageEndpointSuffix: '.core.usgovcloudapi.net',
     keyVaultDnsSuffix: '.vault.usgovcloudapi.net',
     azureDataLakeStoreFileSystemEndpointSuffix: 'N/A',
-    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A'
+    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A',
+    validateAuthority: true
   };
 
   static readonly AzureGermanCloud: {
@@ -358,7 +361,8 @@ export class AzureEnvironment {
     storageEndpointSuffix: '.core.cloudapi.de',
     keyVaultDnsSuffix: '.vault.microsoftazure.de',
     azureDataLakeStoreFileSystemEndpointSuffix: 'N/A',
-    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A'
+    azureDataLakeAnalyticsCatalogAndJobEndpointSuffix: 'N/A',
+    validateAuthority: true
   };
 }
 

--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Client Runtime for Node.js Azure client libraries generated using AutoRest",
   "tags": [
     "node",


### PR DESCRIPTION
Fixes #2952

`validateAuthority` was missing from the type definitions. Because we want to make it easy for users to see what values are used in a given AzureEnvironment, we're using the string and boolean literal types and building something that needs to be assignable to AzureEnvironment.