### PR TITLE
[AutoPR network/resource-manager] network: add https probe which was missing in the spec

### DIFF
--- a/lib/services/networkManagement2/lib/models/index.d.ts
+++ b/lib/services/networkManagement2/lib/models/index.d.ts
@@ -3515,10 +3515,10 @@ export interface LoadBalancingRule extends SubResource {
  * @member {array} [loadBalancingRules] The load balancer rules that use this
  * probe.
  * @member {string} protocol The protocol of the end point. Possible values
- * are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required for
- * the probe to be successful. If 'Http' is specified, a 200 OK response from
- * the specifies URI is required for the probe to be successful. Possible
- * values include: 'Http', 'Tcp'
+ * are: 'Http', 'Tcp', or 'Https'. If 'Tcp' is specified, a received ACK is
+ * required for the probe to be successful. If 'Http' or 'Https' is specified,
+ * a 200 OK response from the specifies URI is required for the probe to be
+ * successful. Possible values include: 'Http', 'Tcp', 'Https'
  * @member {number} port The port for communicating the probe. Possible values
  * range from 1 to 65535, inclusive.
  * @member {number} [intervalInSeconds] The interval, in seconds, for how

--- a/lib/services/networkManagement2/lib/models/probe.js
+++ b/lib/services/networkManagement2/lib/models/probe.js
@@ -23,10 +23,10 @@ class Probe extends models['SubResource'] {
    * @member {array} [loadBalancingRules] The load balancer rules that use this
    * probe.
    * @member {string} protocol The protocol of the end point. Possible values
-   * are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required
-   * for the probe to be successful. If 'Http' is specified, a 200 OK response
-   * from the specifies URI is required for the probe to be successful.
-   * Possible values include: 'Http', 'Tcp'
+   * are: 'Http', 'Tcp', or 'Https'. If 'Tcp' is specified, a received ACK is
+   * required for the probe to be successful. If 'Http' or 'Https' is
+   * specified, a 200 OK response from the specifies URI is required for the
+   * probe to be successful. Possible values include: 'Http', 'Tcp', 'Https'
    * @member {number} port The port for communicating the probe. Possible
    * values range from 1 to 65535, inclusive.
    * @member {number} [intervalInSeconds] The interval, in seconds, for how


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3230