### PR TITLE
Add loganalytics to rollup package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure",
-  "version": "2.3.0-preview",
+  "version": "2.3.1-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1038,6 +1038,14 @@
         "ms-rest": "^2.3.2",
         "ms-rest-azure": "^2.5.2",
         "underscore": "^1.8.3"
+      }
+    },
+    "azure-loganalytics": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/azure-loganalytics/-/azure-loganalytics-0.1.0.tgz",
+      "integrity": "sha512-0zFHBZH2MziWysGrNxVLwQZFhdclnDLXZ1LW3IEPYJOWmOxx4pQHQq0Kw5xhkqOkBBEMtFve/76ZVM9qAAncLA==",
+      "requires": {
+        "ms-rest": "^2.3.3"
       }
     },
     "azure-monitoring": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "azure-gallery": "^2.0.0-pre.20",
     "azure-graph": "^2.2.0",
     "azure-keyvault": "^3.0.4-preview",
+    "azure-loganalytics": "^0.1.0",
     "azure-monitoring": "^0.10.6",
     "azure-sb": "^0.10.6",
     "azure-scheduler": "^0.10.4",

--- a/runtime/ms-rest-azure/package-lock.json
+++ b/runtime/ms-rest-azure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-rest-azure",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Published https://npmjs.com/package/azure-loganalytics, now consuming it from rollup package so we can `require('azure').createLogAnalyticsClient()` @alexeldeib