### PR TITLE
Documentation fixes

### DIFF
--- a/lib/services/face/README.md
+++ b/lib/services/face/README.md
@@ -64,12 +64,12 @@ npm install azure-cognitiveservices-face
  ```javascript
  const FaceAPIClient = require('azure-cognitiveservices-face');
 
- let client = new FaceAPIClient(credentials);
+ let client = new FaceAPIClient(credentials, azureRegion);
 
  let fileStream = fs.createReadStream('pathToSomeImage.jpg');
  client.face.detectInStreamWithHttpOperationResponse(fileStream, {
    returnFaceId: true,
-   returnFaceAttributes: 'age,gender,headPose,smile,facialHair,glasses,emotion,hair,makeup,occlusion,accessories,exposure,noise'
+   returnFaceAttributes: ['age','gender','headPose','smile','facialHair','glasses','emotion','hair','makeup','occlusion','accessories','exposure','noise']
  }).then((httpResponse) => {
    console.log(httpResponse.response.body);
  }).catch((err) => {


### PR DESCRIPTION
In `README.md` of `azure-sdk-for-node/lib/services/face/`, `new FaceAPIClient` should have parameter `azureRegion`, and `returnFaceAttributes` should be an array, not a comma-delimited list
