### PR TITLE
[AutoPR keyvault/data-plane] Restoring the x-ms-client-name property accidently stripped from kty …

### DIFF
--- a/lib/services/keyvault/lib/keyVaultClient.d.ts
+++ b/lib/services/keyvault/lib/keyVaultClient.d.ts
@@ -3516,8 +3516,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -3638,8 +3638,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -3789,8 +3789,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -3921,8 +3921,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -4206,9 +4206,9 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
    * the private key can be exported.
    *
-   * @param {string} [certificatePolicy.keyProperties.kty] The type of key pair
-   * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
-   * 'RSA', 'RSA-HSM', 'oct'
+   * @param {string} [certificatePolicy.keyProperties.keyType] The type of key
+   * pair to be used for the certificate. Possible values include: 'EC',
+   * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [certificatePolicy.keyProperties.keySize] The key size in
    * bits. For example: 2048, 3072, or 4096 for RSA.
@@ -4319,9 +4319,9 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
    * the private key can be exported.
    *
-   * @param {string} [certificatePolicy.keyProperties.kty] The type of key pair
-   * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
-   * 'RSA', 'RSA-HSM', 'oct'
+   * @param {string} [certificatePolicy.keyProperties.keyType] The type of key
+   * pair to be used for the certificate. Possible values include: 'EC',
+   * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [certificatePolicy.keyProperties.keySize] The key size in
    * bits. For example: 2048, 3072, or 4096 for RSA.
@@ -4458,8 +4458,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -4585,8 +4585,8 @@ export default class KeyVaultClient extends AzureServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key

--- a/lib/services/keyvault/lib/keyVaultClient.js
+++ b/lib/services/keyvault/lib/keyVaultClient.js
@@ -7022,8 +7022,8 @@ function _deleteCertificateIssuer(vaultBaseUrl, issuerName, options, callback) {
  * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
  * Indicates if the private key can be exported.
  *
- * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
- * key pair to be used for the certificate. Possible values include: 'EC',
+ * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+ * of key pair to be used for the certificate. Possible values include: 'EC',
  * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  *
  * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -7313,8 +7313,8 @@ function _createCertificate(vaultBaseUrl, certificateName, options, callback) {
  * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
  * Indicates if the private key can be exported.
  *
- * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
- * key pair to be used for the certificate. Possible values include: 'EC',
+ * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+ * of key pair to be used for the certificate. Possible values include: 'EC',
  * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  *
  * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -7916,9 +7916,9 @@ function _getCertificatePolicy(vaultBaseUrl, certificateName, options, callback)
  * @param {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
  * the private key can be exported.
  *
- * @param {string} [certificatePolicy.keyProperties.kty] The type of key pair
- * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
- * 'RSA', 'RSA-HSM', 'oct'
+ * @param {string} [certificatePolicy.keyProperties.keyType] The type of key
+ * pair to be used for the certificate. Possible values include: 'EC',
+ * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  *
  * @param {number} [certificatePolicy.keyProperties.keySize] The key size in
  * bits. For example: 2048, 3072, or 4096 for RSA.
@@ -8175,8 +8175,8 @@ function _updateCertificatePolicy(vaultBaseUrl, certificateName, certificatePoli
  * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
  * Indicates if the private key can be exported.
  *
- * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
- * key pair to be used for the certificate. Possible values include: 'EC',
+ * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+ * of key pair to be used for the certificate. Possible values include: 'EC',
  * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  *
  * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -20160,8 +20160,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -20294,8 +20294,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -20460,8 +20460,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -20604,8 +20604,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -20958,9 +20958,9 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
    * the private key can be exported.
    *
-   * @param {string} [certificatePolicy.keyProperties.kty] The type of key pair
-   * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
-   * 'RSA', 'RSA-HSM', 'oct'
+   * @param {string} [certificatePolicy.keyProperties.keyType] The type of key
+   * pair to be used for the certificate. Possible values include: 'EC',
+   * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [certificatePolicy.keyProperties.keySize] The key size in
    * bits. For example: 2048, 3072, or 4096 for RSA.
@@ -21083,9 +21083,9 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
    * the private key can be exported.
    *
-   * @param {string} [certificatePolicy.keyProperties.kty] The type of key pair
-   * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
-   * 'RSA', 'RSA-HSM', 'oct'
+   * @param {string} [certificatePolicy.keyProperties.keyType] The type of key
+   * pair to be used for the certificate. Possible values include: 'EC',
+   * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [certificatePolicy.keyProperties.keySize] The key size in
    * bits. For example: 2048, 3072, or 4096 for RSA.
@@ -21237,8 +21237,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key
@@ -21376,8 +21376,8 @@ class KeyVaultClient extends ServiceClient {
    * @param {boolean} [options.certificatePolicy.keyProperties.exportable]
    * Indicates if the private key can be exported.
    *
-   * @param {string} [options.certificatePolicy.keyProperties.kty] The type of
-   * key pair to be used for the certificate. Possible values include: 'EC',
+   * @param {string} [options.certificatePolicy.keyProperties.keyType] The type
+   * of key pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    *
    * @param {number} [options.certificatePolicy.keyProperties.keySize] The key

--- a/lib/services/keyvault/lib/models/certificateBundle.js
+++ b/lib/services/keyvault/lib/models/certificateBundle.js
@@ -29,7 +29,7 @@ class CertificateBundle {
    * certificate.
    * @member {boolean} [policy.keyProperties.exportable] Indicates if the
    * private key can be exported.
-   * @member {string} [policy.keyProperties.kty] The type of key pair to be
+   * @member {string} [policy.keyProperties.keyType] The type of key pair to be
    * used for the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA',
    * 'RSA-HSM', 'oct'
    * @member {number} [policy.keyProperties.keySize] The key size in bits. For

--- a/lib/services/keyvault/lib/models/certificateCreateParameters.js
+++ b/lib/services/keyvault/lib/models/certificateCreateParameters.js
@@ -26,7 +26,7 @@ class CertificateCreateParameters {
    * backing a certificate.
    * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates
    * if the private key can be exported.
-   * @member {string} [certificatePolicy.keyProperties.kty] The type of key
+   * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
    * pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    * @member {number} [certificatePolicy.keyProperties.keySize] The key size in

--- a/lib/services/keyvault/lib/models/certificateImportParameters.js
+++ b/lib/services/keyvault/lib/models/certificateImportParameters.js
@@ -31,7 +31,7 @@ class CertificateImportParameters {
    * backing a certificate.
    * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates
    * if the private key can be exported.
-   * @member {string} [certificatePolicy.keyProperties.kty] The type of key
+   * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
    * pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    * @member {number} [certificatePolicy.keyProperties.keySize] The key size in

--- a/lib/services/keyvault/lib/models/certificatePolicy.js
+++ b/lib/services/keyvault/lib/models/certificatePolicy.js
@@ -24,8 +24,8 @@ class CertificatePolicy {
    * certificate.
    * @member {boolean} [keyProperties.exportable] Indicates if the private key
    * can be exported.
-   * @member {string} [keyProperties.kty] The type of key pair to be used for
-   * the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA',
+   * @member {string} [keyProperties.keyType] The type of key pair to be used
+   * for the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA',
    * 'RSA-HSM', 'oct'
    * @member {number} [keyProperties.keySize] The key size in bits. For
    * example: 2048, 3072, or 4096 for RSA.

--- a/lib/services/keyvault/lib/models/certificateUpdateParameters.js
+++ b/lib/services/keyvault/lib/models/certificateUpdateParameters.js
@@ -26,7 +26,7 @@ class CertificateUpdateParameters {
    * backing a certificate.
    * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates
    * if the private key can be exported.
-   * @member {string} [certificatePolicy.keyProperties.kty] The type of key
+   * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
    * pair to be used for the certificate. Possible values include: 'EC',
    * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    * @member {number} [certificatePolicy.keyProperties.keySize] The key size in

--- a/lib/services/keyvault/lib/models/index.d.ts
+++ b/lib/services/keyvault/lib/models/index.d.ts
@@ -415,8 +415,9 @@ export interface CertificateIssuerItem {
  * Properties of the key pair backing a certificate.
  *
  * @member {boolean} [exportable] Indicates if the private key can be exported.
- * @member {string} [kty] The type of key pair to be used for the certificate.
- * Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
+ * @member {string} [keyType] The type of key pair to be used for the
+ * certificate. Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM',
+ * 'oct'
  * @member {number} [keySize] The key size in bits. For example: 2048, 3072, or
  * 4096 for RSA.
  * @member {boolean} [reuseKey] Indicates if the same key pair will be used on
@@ -427,7 +428,7 @@ export interface CertificateIssuerItem {
  */
 export interface KeyProperties {
   exportable?: boolean;
-  kty?: string;
+  keyType?: string;
   keySize?: number;
   reuseKey?: boolean;
   curve?: string;
@@ -570,8 +571,8 @@ export interface IssuerParameters {
  * certificate.
  * @member {boolean} [keyProperties.exportable] Indicates if the private key
  * can be exported.
- * @member {string} [keyProperties.kty] The type of key pair to be used for the
- * certificate. Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM',
+ * @member {string} [keyProperties.keyType] The type of key pair to be used for
+ * the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM',
  * 'oct'
  * @member {number} [keyProperties.keySize] The key size in bits. For example:
  * 2048, 3072, or 4096 for RSA.
@@ -644,8 +645,8 @@ export interface CertificatePolicy {
  * certificate.
  * @member {boolean} [policy.keyProperties.exportable] Indicates if the private
  * key can be exported.
- * @member {string} [policy.keyProperties.kty] The type of key pair to be used
- * for the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA',
+ * @member {string} [policy.keyProperties.keyType] The type of key pair to be
+ * used for the certificate. Possible values include: 'EC', 'EC-HSM', 'RSA',
  * 'RSA-HSM', 'oct'
  * @member {number} [policy.keyProperties.keySize] The key size in bits. For
  * example: 2048, 3072, or 4096 for RSA.
@@ -1175,9 +1176,9 @@ export interface SecretUpdateParameters {
  * backing a certificate.
  * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
  * the private key can be exported.
- * @member {string} [certificatePolicy.keyProperties.kty] The type of key pair
- * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
- * 'RSA', 'RSA-HSM', 'oct'
+ * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
+ * pair to be used for the certificate. Possible values include: 'EC',
+ * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  * @member {number} [certificatePolicy.keyProperties.keySize] The key size in
  * bits. For example: 2048, 3072, or 4096 for RSA.
  * @member {boolean} [certificatePolicy.keyProperties.reuseKey] Indicates if
@@ -1268,9 +1269,9 @@ export interface CertificateCreateParameters {
  * backing a certificate.
  * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
  * the private key can be exported.
- * @member {string} [certificatePolicy.keyProperties.kty] The type of key pair
- * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
- * 'RSA', 'RSA-HSM', 'oct'
+ * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
+ * pair to be used for the certificate. Possible values include: 'EC',
+ * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  * @member {number} [certificatePolicy.keyProperties.keySize] The key size in
  * bits. For example: 2048, 3072, or 4096 for RSA.
  * @member {boolean} [certificatePolicy.keyProperties.reuseKey] Indicates if
@@ -1358,9 +1359,9 @@ export interface CertificateImportParameters {
  * backing a certificate.
  * @member {boolean} [certificatePolicy.keyProperties.exportable] Indicates if
  * the private key can be exported.
- * @member {string} [certificatePolicy.keyProperties.kty] The type of key pair
- * to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
- * 'RSA', 'RSA-HSM', 'oct'
+ * @member {string} [certificatePolicy.keyProperties.keyType] The type of key
+ * pair to be used for the certificate. Possible values include: 'EC',
+ * 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
  * @member {number} [certificatePolicy.keyProperties.keySize] The key size in
  * bits. For example: 2048, 3072, or 4096 for RSA.
  * @member {boolean} [certificatePolicy.keyProperties.reuseKey] Indicates if

--- a/lib/services/keyvault/lib/models/keyProperties.js
+++ b/lib/services/keyvault/lib/models/keyProperties.js
@@ -19,7 +19,7 @@ class KeyProperties {
    * Create a KeyProperties.
    * @member {boolean} [exportable] Indicates if the private key can be
    * exported.
-   * @member {string} [kty] The type of key pair to be used for the
+   * @member {string} [keyType] The type of key pair to be used for the
    * certificate. Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM',
    * 'oct'
    * @member {number} [keySize] The key size in bits. For example: 2048, 3072,
@@ -54,7 +54,7 @@ class KeyProperties {
               name: 'Boolean'
             }
           },
-          kty: {
+          keyType: {
             required: false,
             serializedName: 'kty',
             type: {


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3288