### PR TITLE
Add package 'request' as a dependency of ms-rest-azure

### DIFF
--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -29,7 +29,8 @@
     "async": "2.6.0",
     "moment": "^2.22.2",
     "ms-rest": "^2.3.2",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "request": "^2.87.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",


### PR DESCRIPTION
https://github.com/pnpm/pnpm/issues/1258#issuecomment-402772376

ms-rest-azure uses request

https://github.com/Azure/azure-sdk-for-node/blob/d82264c00bf00447547ba452495a56bda3400ff9/runtime/ms-rest-azure/lib/credentials/msiVmTokenCredentials.js#L12

But doesn't have it in the package.json as a dependency

https://github.com/Azure/azure-sdk-for-node/blob/d82264c00bf00447547ba452495a56bda3400ff9/runtime/ms-rest-azure/package.json