### PR TITLE
[AutoPR datafactory/resource-manager] [Datafactory] Bringing back additionalProperties in Activity removed by mistake

### DIFF
--- a/lib/services/datafactoryManagement/lib/models/activity.js
+++ b/lib/services/datafactoryManagement/lib/models/activity.js
@@ -40,6 +40,18 @@ class Activity {
       serializedName: 'Activity',
       type: {
         name: 'Composite',
+        additionalProperties: {
+          type: {
+            name: 'Dictionary',
+            value: {
+                required: false,
+                serializedName: 'ObjectElementType',
+                type: {
+                  name: 'Object'
+                }
+            }
+          }
+        },
         polymorphicDiscriminator: {
           serializedName: 'type',
           clientName: 'type'

--- a/lib/services/datafactoryManagement/lib/models/forEachActivity.js
+++ b/lib/services/datafactoryManagement/lib/models/forEachActivity.js
@@ -152,6 +152,18 @@ class ForEachActivity extends models['ControlActivity'] {
                   serializedName: 'ActivityElementType',
                   type: {
                     name: 'Composite',
+                    additionalProperties: {
+                      type: {
+                        name: 'Dictionary',
+                        value: {
+                            required: false,
+                            serializedName: 'ObjectElementType',
+                            type: {
+                              name: 'Object'
+                            }
+                        }
+                      }
+                    },
                     polymorphicDiscriminator: {
                       serializedName: 'type',
                       clientName: 'type'

--- a/lib/services/datafactoryManagement/lib/models/ifConditionActivity.js
+++ b/lib/services/datafactoryManagement/lib/models/ifConditionActivity.js
@@ -139,6 +139,18 @@ class IfConditionActivity extends models['ControlActivity'] {
                   serializedName: 'ActivityElementType',
                   type: {
                     name: 'Composite',
+                    additionalProperties: {
+                      type: {
+                        name: 'Dictionary',
+                        value: {
+                            required: false,
+                            serializedName: 'ObjectElementType',
+                            type: {
+                              name: 'Object'
+                            }
+                        }
+                      }
+                    },
                     polymorphicDiscriminator: {
                       serializedName: 'type',
                       clientName: 'type'
@@ -159,6 +171,18 @@ class IfConditionActivity extends models['ControlActivity'] {
                   serializedName: 'ActivityElementType',
                   type: {
                     name: 'Composite',
+                    additionalProperties: {
+                      type: {
+                        name: 'Dictionary',
+                        value: {
+                            required: false,
+                            serializedName: 'ObjectElementType',
+                            type: {
+                              name: 'Object'
+                            }
+                        }
+                      }
+                    },
                     polymorphicDiscriminator: {
                       serializedName: 'type',
                       clientName: 'type'

--- a/lib/services/datafactoryManagement/lib/models/index.d.ts
+++ b/lib/services/datafactoryManagement/lib/models/index.d.ts
@@ -532,6 +532,11 @@ export interface Activity {
   dependsOn?: ActivityDependency[];
   userProperties?: UserProperty[];
   type: string;
+  /**
+   * @property Describes unknown properties. The value of an unknown property
+   * can be of "any" type.
+   */
+  [property: string]: any;
 }
 
 /**

--- a/lib/services/datafactoryManagement/lib/models/pipelineResource.js
+++ b/lib/services/datafactoryManagement/lib/models/pipelineResource.js
@@ -107,6 +107,18 @@ class PipelineResource extends models['SubResource'] {
                   serializedName: 'ActivityElementType',
                   type: {
                     name: 'Composite',
+                    additionalProperties: {
+                      type: {
+                        name: 'Dictionary',
+                        value: {
+                            required: false,
+                            serializedName: 'ObjectElementType',
+                            type: {
+                              name: 'Object'
+                            }
+                        }
+                      }
+                    },
                     polymorphicDiscriminator: {
                       serializedName: 'type',
                       clientName: 'type'

--- a/lib/services/datafactoryManagement/lib/models/untilActivity.js
+++ b/lib/services/datafactoryManagement/lib/models/untilActivity.js
@@ -145,6 +145,18 @@ class UntilActivity extends models['ControlActivity'] {
                   serializedName: 'ActivityElementType',
                   type: {
                     name: 'Composite',
+                    additionalProperties: {
+                      type: {
+                        name: 'Dictionary',
+                        value: {
+                            required: false,
+                            serializedName: 'ObjectElementType',
+                            type: {
+                              name: 'Object'
+                            }
+                        }
+                      }
+                    },
                     polymorphicDiscriminator: {
                       serializedName: 'type',
                       clientName: 'type'


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3493