### PR TITLE
Fixed issue with environment credentials

### DIFF
--- a/lib/services/computeManagement2/lib/computeManagementClient.js
+++ b/lib/services/computeManagement2/lib/computeManagementClient.js
@@ -55,7 +55,7 @@ class ComputeManagementClient extends ServiceClient {
     this.generateClientRequestId = true;
     this.baseUri = baseUri;
     if (!this.baseUri) {
-      this.baseUri = 'https://management.azure.com';
+      this.baseUri = credentials.environment.resourceManagerEndpointUrl || 'https://management.azure.com';  // Should pull the base URI from the environment of the credentials by default
     }
     this.credentials = credentials;
     this.subscriptionId = subscriptionId;


### PR DESCRIPTION
We ran into an issue where our Azure US GOV subscription would not be found.  We weren't passing in a new base uri because we assumed that the resource management uri would be taken from the credentials.  This was not the case and it caused some major debugging to occur.


It turns out, that the there was a hard coded "magic string" that caused these issues, and this pull request fixes that problem.
