### PR TITLE
[AutoPR network/resource-manager] Use only PublicIpAddress in Azure Firewall, not both Public and InternalPublic

### DIFF
--- a/lib/services/networkManagement2/lib/models/azureFirewallIPConfiguration.js
+++ b/lib/services/networkManagement2/lib/models/azureFirewallIPConfiguration.js
@@ -25,11 +25,8 @@ class AzureFirewallIPConfiguration extends models['SubResource'] {
    * @member {object} [subnet] Reference of the subnet resource. This resource
    * must be named 'AzureFirewallSubnet'.
    * @member {string} [subnet.id] Resource ID.
-   * @member {object} [internalPublicIpAddress] Reference of the PublicIP
-   * resource. This field is a mandatory input.
-   * @member {string} [internalPublicIpAddress.id] Resource ID.
    * @member {object} [publicIPAddress] Reference of the PublicIP resource.
-   * This field is populated in the output.
+   * This field is a mandatory input if subnet is not null.
    * @member {string} [publicIPAddress.id] Resource ID.
    * @member {string} [provisioningState] The provisioning state of the
    * resource. Possible values include: 'Succeeded', 'Updating', 'Deleting',
@@ -74,14 +71,6 @@ class AzureFirewallIPConfiguration extends models['SubResource'] {
           subnet: {
             required: false,
             serializedName: 'properties.subnet',
-            type: {
-              name: 'Composite',
-              className: 'SubResource'
-            }
-          },
-          internalPublicIpAddress: {
-            required: false,
-            serializedName: 'properties.internalPublicIpAddress',
             type: {
               name: 'Composite',
               className: 'SubResource'

--- a/lib/services/networkManagement2/lib/models/index.d.ts
+++ b/lib/services/networkManagement2/lib/models/index.d.ts
@@ -2584,11 +2584,8 @@ export interface TagsObject {
  * @member {object} [subnet] Reference of the subnet resource. This resource
  * must be named 'AzureFirewallSubnet'.
  * @member {string} [subnet.id] Resource ID.
- * @member {object} [internalPublicIpAddress] Reference of the PublicIP
- * resource. This field is a mandatory input.
- * @member {string} [internalPublicIpAddress.id] Resource ID.
  * @member {object} [publicIPAddress] Reference of the PublicIP resource. This
- * field is populated in the output.
+ * field is a mandatory input if subnet is not null.
  * @member {string} [publicIPAddress.id] Resource ID.
  * @member {string} [provisioningState] The provisioning state of the resource.
  * Possible values include: 'Succeeded', 'Updating', 'Deleting', 'Failed'
@@ -2600,7 +2597,6 @@ export interface TagsObject {
 export interface AzureFirewallIPConfiguration extends SubResource {
   privateIPAddress?: string;
   subnet?: SubResource;
-  internalPublicIpAddress?: SubResource;
   publicIPAddress?: SubResource;
   provisioningState?: string;
   name?: string;


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3743