### PR TITLE
[AutoPR containerservices/resource-manager] Remove serverAppSecret which is not required for AKS cluster updates

### DIFF
--- a/lib/services/containerservicesManagement/lib/models/index.d.ts
+++ b/lib/services/containerservicesManagement/lib/models/index.d.ts
@@ -708,14 +708,14 @@ export interface ManagedClusterAddonProfile {
  *
  * @member {string} clientAppID The client AAD application ID.
  * @member {string} serverAppID The server AAD application ID.
- * @member {string} serverAppSecret The server AAD application secret.
+ * @member {string} [serverAppSecret] The server AAD application secret.
  * @member {string} [tenantID] The AAD tenant ID to use for authentication. If
  * not specified, will use the tenant of the deployment subscription.
  */
 export interface ManagedClusterAADProfile {
   clientAppID: string;
   serverAppID: string;
-  serverAppSecret: string;
+  serverAppSecret?: string;
   tenantID?: string;
 }
 

--- a/lib/services/containerservicesManagement/lib/models/managedClusterAADProfile.js
+++ b/lib/services/containerservicesManagement/lib/models/managedClusterAADProfile.js
@@ -19,7 +19,7 @@ class ManagedClusterAADProfile {
    * Create a ManagedClusterAADProfile.
    * @member {string} clientAppID The client AAD application ID.
    * @member {string} serverAppID The server AAD application ID.
-   * @member {string} serverAppSecret The server AAD application secret.
+   * @member {string} [serverAppSecret] The server AAD application secret.
    * @member {string} [tenantID] The AAD tenant ID to use for authentication.
    * If not specified, will use the tenant of the deployment subscription.
    */
@@ -55,7 +55,7 @@ class ManagedClusterAADProfile {
             }
           },
           serverAppSecret: {
-            required: true,
+            required: false,
             serializedName: 'serverAppSecret',
             type: {
               name: 'String'

--- a/lib/services/containerservicesManagement/lib/operations/index.d.ts
+++ b/lib/services/containerservicesManagement/lib/operations/index.d.ts
@@ -1951,7 +1951,7 @@ export interface ManagedClusters {
      * @param {string} parameters.aadProfile.serverAppID The server AAD application
      * ID.
      *
-     * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+     * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
      * application secret.
      *
      * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -2060,7 +2060,7 @@ export interface ManagedClusters {
      * @param {string} parameters.aadProfile.serverAppID The server AAD application
      * ID.
      *
-     * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+     * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
      * application secret.
      *
      * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -2323,7 +2323,7 @@ export interface ManagedClusters {
      * @param {string} parameters.aadProfile.serverAppID The server AAD application
      * ID.
      *
-     * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+     * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
      * application secret.
      *
      * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -2432,7 +2432,7 @@ export interface ManagedClusters {
      * @param {string} parameters.aadProfile.serverAppID The server AAD application
      * ID.
      *
-     * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+     * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
      * application secret.
      *
      * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use

--- a/lib/services/containerservicesManagement/lib/operations/managedClusters.js
+++ b/lib/services/containerservicesManagement/lib/operations/managedClusters.js
@@ -1116,7 +1116,7 @@ function _get(resourceGroupName, resourceName, options, callback) {
  * @param {string} parameters.aadProfile.serverAppID The server AAD application
  * ID.
  *
- * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+ * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
  * application secret.
  *
  * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -1432,7 +1432,7 @@ function _deleteMethod(resourceGroupName, resourceName, options, callback) {
  * @param {string} parameters.aadProfile.serverAppID The server AAD application
  * ID.
  *
- * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+ * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
  * application secret.
  *
  * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -2924,7 +2924,7 @@ class ManagedClusters {
    * @param {string} parameters.aadProfile.serverAppID The server AAD application
    * ID.
    *
-   * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+   * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
    * application secret.
    *
    * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -3045,7 +3045,7 @@ class ManagedClusters {
    * @param {string} parameters.aadProfile.serverAppID The server AAD application
    * ID.
    *
-   * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+   * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
    * application secret.
    *
    * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -3377,7 +3377,7 @@ class ManagedClusters {
    * @param {string} parameters.aadProfile.serverAppID The server AAD application
    * ID.
    *
-   * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+   * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
    * application secret.
    *
    * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use
@@ -3498,7 +3498,7 @@ class ManagedClusters {
    * @param {string} parameters.aadProfile.serverAppID The server AAD application
    * ID.
    *
-   * @param {string} parameters.aadProfile.serverAppSecret The server AAD
+   * @param {string} [parameters.aadProfile.serverAppSecret] The server AAD
    * application secret.
    *
    * @param {string} [parameters.aadProfile.tenantID] The AAD tenant ID to use

--- a/lib/services/containerservicesManagement/package.json
+++ b/lib/services/containerservicesManagement/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "main": "./lib/containerServiceClient.js",
   "types": "./lib/containerServiceClient.d.ts",
-  "homepage": "https://github.com/azure/azure-sdk-for-node/tree/master/lib/services/containerservicesManagement",
+  "homepage": "https://github.com/azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-node.git"


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3949