### PR TITLE
[AutoPR network/resource-manager] Fix incorrect API versions in Network's examples

### DIFF
--- a/lib/services/networkManagement2/package.json
+++ b/lib/services/networkManagement2/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "main": "./lib/networkManagementClient.js",
   "types": "./lib/networkManagementClient.d.ts",
-  "homepage": "https://github.com/azure/azure-sdk-for-node/tree/master/lib/services/networkManagement2",
+  "homepage": "https://github.com/azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-node.git"


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3953