### PR TITLE
[AutoPR web/resource-manager] Updated the AppService Swagger to include ElasticPremium and ElasticIsolated Skus, and a new MaximumElasticWorkerCount parameter.

### DIFF
--- a/lib/services/websiteManagement2/lib/models/appServicePlan.js
+++ b/lib/services/websiteManagement2/lib/models/appServicePlan.js
@@ -42,6 +42,8 @@ class AppServicePlan extends models['Resource'] {
    * this App Service plan can be scaled independently.
    * If <code>false</code>, apps assigned to this App Service plan will scale
    * to all instances of the plan. Default value: false .
+   * @member {number} [maximumElasticWorkerCount] Maximum number of total
+   * workers allowed for this ElasticScaleEnabled App Service Plan
    * @member {number} [numberOfSites] Number of apps assigned to this App
    * Service plan.
    * @member {boolean} [isSpot] If <code>true</code>, this App Service Plan
@@ -215,6 +217,13 @@ class AppServicePlan extends models['Resource'] {
             defaultValue: false,
             type: {
               name: 'Boolean'
+            }
+          },
+          maximumElasticWorkerCount: {
+            required: false,
+            serializedName: 'properties.maximumElasticWorkerCount',
+            type: {
+              name: 'Number'
             }
           },
           numberOfSites: {

--- a/lib/services/websiteManagement2/lib/models/appServicePlanPatchResource.js
+++ b/lib/services/websiteManagement2/lib/models/appServicePlanPatchResource.js
@@ -42,6 +42,8 @@ class AppServicePlanPatchResource extends models['ProxyOnlyResource'] {
    * this App Service plan can be scaled independently.
    * If <code>false</code>, apps assigned to this App Service plan will scale
    * to all instances of the plan. Default value: false .
+   * @member {number} [maximumElasticWorkerCount] Maximum number of total
+   * workers allowed for this ElasticScaleEnabled App Service Plan
    * @member {number} [numberOfSites] Number of apps assigned to this App
    * Service plan.
    * @member {boolean} [isSpot] If <code>true</code>, this App Service Plan
@@ -174,6 +176,13 @@ class AppServicePlanPatchResource extends models['ProxyOnlyResource'] {
             defaultValue: false,
             type: {
               name: 'Boolean'
+            }
+          },
+          maximumElasticWorkerCount: {
+            required: false,
+            serializedName: 'properties.maximumElasticWorkerCount',
+            type: {
+              name: 'Number'
             }
           },
           numberOfSites: {

--- a/lib/services/websiteManagement2/lib/models/index.d.ts
+++ b/lib/services/websiteManagement2/lib/models/index.d.ts
@@ -1811,6 +1811,8 @@ export interface SkuDescription {
  * this App Service plan can be scaled independently.
  * If <code>false</code>, apps assigned to this App Service plan will scale to
  * all instances of the plan. Default value: false .
+ * @member {number} [maximumElasticWorkerCount] Maximum number of total workers
+ * allowed for this ElasticScaleEnabled App Service Plan
  * @member {number} [numberOfSites] Number of apps assigned to this App Service
  * plan.
  * @member {boolean} [isSpot] If <code>true</code>, this App Service Plan owns
@@ -1861,6 +1863,7 @@ export interface AppServicePlan extends Resource {
   readonly maximumNumberOfWorkers?: number;
   readonly geoRegion?: string;
   perSiteScaling?: boolean;
+  maximumElasticWorkerCount?: number;
   readonly numberOfSites?: number;
   isSpot?: boolean;
   spotExpirationTime?: Date;
@@ -6906,6 +6909,8 @@ export interface WorkerPoolResource extends ProxyOnlyResource {
  * this App Service plan can be scaled independently.
  * If <code>false</code>, apps assigned to this App Service plan will scale to
  * all instances of the plan. Default value: false .
+ * @member {number} [maximumElasticWorkerCount] Maximum number of total workers
+ * allowed for this ElasticScaleEnabled App Service Plan
  * @member {number} [numberOfSites] Number of apps assigned to this App Service
  * plan.
  * @member {boolean} [isSpot] If <code>true</code>, this App Service Plan owns
@@ -6936,6 +6941,7 @@ export interface AppServicePlanPatchResource extends ProxyOnlyResource {
   readonly maximumNumberOfWorkers?: number;
   readonly geoRegion?: string;
   perSiteScaling?: boolean;
+  maximumElasticWorkerCount?: number;
   readonly numberOfSites?: number;
   isSpot?: boolean;
   spotExpirationTime?: Date;

--- a/lib/services/websiteManagement2/lib/operations/appServicePlans.js
+++ b/lib/services/websiteManagement2/lib/operations/appServicePlans.js
@@ -513,6 +513,9 @@ function _get(resourceGroupName, name, options, callback) {
  * If <code>false</code>, apps assigned to this App Service plan will scale to
  * all instances of the plan.
  *
+ * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+ * total workers allowed for this ElasticScaleEnabled App Service Plan
+ *
  * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
  * Service Plan owns spot instances.
  *
@@ -817,6 +820,9 @@ function _deleteMethod(resourceGroupName, name, options, callback) {
  * assigned to this App Service plan can be scaled independently.
  * If <code>false</code>, apps assigned to this App Service plan will scale to
  * all instances of the plan.
+ *
+ * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+ * total workers allowed for this ElasticScaleEnabled App Service Plan
  *
  * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
  * Service Plan owns spot instances.
@@ -5113,6 +5119,9 @@ function _rebootWorker(resourceGroupName, name, workerName, options, callback) {
  * If <code>false</code>, apps assigned to this App Service plan will scale to
  * all instances of the plan.
  *
+ * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+ * total workers allowed for this ElasticScaleEnabled App Service Plan
+ *
  * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
  * Service Plan owns spot instances.
  *
@@ -6761,6 +6770,9 @@ class AppServicePlans {
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
    *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
+   *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.
    *
@@ -6876,6 +6888,9 @@ class AppServicePlans {
    * assigned to this App Service plan can be scaled independently.
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
+   *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
    *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.
@@ -7106,6 +7121,9 @@ class AppServicePlans {
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
    *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
+   *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.
    *
@@ -7183,6 +7201,9 @@ class AppServicePlans {
    * assigned to this App Service plan can be scaled independently.
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
+   *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
    *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.
@@ -9660,6 +9681,9 @@ class AppServicePlans {
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
    *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
+   *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.
    *
@@ -9775,6 +9799,9 @@ class AppServicePlans {
    * assigned to this App Service plan can be scaled independently.
    * If <code>false</code>, apps assigned to this App Service plan will scale to
    * all instances of the plan.
+   *
+   * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+   * total workers allowed for this ElasticScaleEnabled App Service Plan
    *
    * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
    * Service Plan owns spot instances.

--- a/lib/services/websiteManagement2/lib/operations/index.d.ts
+++ b/lib/services/websiteManagement2/lib/operations/index.d.ts
@@ -56415,6 +56415,9 @@ export interface AppServicePlans {
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
      *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
+     *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.
      *
@@ -56518,6 +56521,9 @@ export interface AppServicePlans {
      * assigned to this App Service plan can be scaled independently.
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
+     *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
      *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.
@@ -56706,6 +56712,9 @@ export interface AppServicePlans {
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
      *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
+     *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.
      *
@@ -56771,6 +56780,9 @@ export interface AppServicePlans {
      * assigned to this App Service plan can be scaled independently.
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
+     *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
      *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.
@@ -58612,6 +58624,9 @@ export interface AppServicePlans {
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
      *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
+     *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.
      *
@@ -58715,6 +58730,9 @@ export interface AppServicePlans {
      * assigned to this App Service plan can be scaled independently.
      * If <code>false</code>, apps assigned to this App Service plan will scale to
      * all instances of the plan.
+     *
+     * @param {number} [appServicePlan.maximumElasticWorkerCount] Maximum number of
+     * total workers allowed for this ElasticScaleEnabled App Service Plan
      *
      * @param {boolean} [appServicePlan.isSpot] If <code>true</code>, this App
      * Service Plan owns spot instances.

--- a/lib/services/websiteManagement2/lib/webSiteManagementClient.d.ts
+++ b/lib/services/websiteManagement2/lib/webSiteManagementClient.d.ts
@@ -618,7 +618,7 @@ export default class WebSiteManagementClient extends AzureServiceClient {
    *
    * @param {string} [options.sku] Name of SKU used to filter the regions.
    * Possible values include: 'Free', 'Shared', 'Basic', 'Standard', 'Premium',
-   * 'Dynamic', 'Isolated', 'PremiumV2'
+   * 'Dynamic', 'Isolated', 'PremiumV2', 'ElasticPremium', 'ElasticIsolated'
    *
    * @param {boolean} [options.linuxWorkersEnabled] Specify <code>true</code> if
    * you want to filter to only regions that support Linux workers.
@@ -646,7 +646,7 @@ export default class WebSiteManagementClient extends AzureServiceClient {
    *
    * @param {string} [options.sku] Name of SKU used to filter the regions.
    * Possible values include: 'Free', 'Shared', 'Basic', 'Standard', 'Premium',
-   * 'Dynamic', 'Isolated', 'PremiumV2'
+   * 'Dynamic', 'Isolated', 'PremiumV2', 'ElasticPremium', 'ElasticIsolated'
    *
    * @param {boolean} [options.linuxWorkersEnabled] Specify <code>true</code> if
    * you want to filter to only regions that support Linux workers.

--- a/lib/services/websiteManagement2/lib/webSiteManagementClient.js
+++ b/lib/services/websiteManagement2/lib/webSiteManagementClient.js
@@ -1237,7 +1237,7 @@ function _getSubscriptionDeploymentLocations(options, callback) {
  *
  * @param {string} [options.sku] Name of SKU used to filter the regions.
  * Possible values include: 'Free', 'Shared', 'Basic', 'Standard', 'Premium',
- * 'Dynamic', 'Isolated', 'PremiumV2'
+ * 'Dynamic', 'Isolated', 'PremiumV2', 'ElasticPremium', 'ElasticIsolated'
  *
  * @param {boolean} [options.linuxWorkersEnabled] Specify <code>true</code> if
  * you want to filter to only regions that support Linux workers.
@@ -4028,7 +4028,7 @@ class WebSiteManagementClient extends ServiceClient {
    *
    * @param {string} [options.sku] Name of SKU used to filter the regions.
    * Possible values include: 'Free', 'Shared', 'Basic', 'Standard', 'Premium',
-   * 'Dynamic', 'Isolated', 'PremiumV2'
+   * 'Dynamic', 'Isolated', 'PremiumV2', 'ElasticPremium', 'ElasticIsolated'
    *
    * @param {boolean} [options.linuxWorkersEnabled] Specify <code>true</code> if
    * you want to filter to only regions that support Linux workers.
@@ -4068,7 +4068,7 @@ class WebSiteManagementClient extends ServiceClient {
    *
    * @param {string} [options.sku] Name of SKU used to filter the regions.
    * Possible values include: 'Free', 'Shared', 'Basic', 'Standard', 'Premium',
-   * 'Dynamic', 'Isolated', 'PremiumV2'
+   * 'Dynamic', 'Isolated', 'PremiumV2', 'ElasticPremium', 'ElasticIsolated'
    *
    * @param {boolean} [options.linuxWorkersEnabled] Specify <code>true</code> if
    * you want to filter to only regions that support Linux workers.

--- a/lib/services/websiteManagement2/package.json
+++ b/lib/services/websiteManagement2/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "main": "./lib/webSiteManagementClient.js",
   "types": "./lib/webSiteManagementClient.d.ts",
-  "homepage": "https://github.com/azure/azure-sdk-for-node/tree/master/lib/services/websiteManagement2",
+  "homepage": "https://github.com/azure/azure-sdk-for-node",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-node.git"


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4006