### PR TITLE
[AutoPR trafficmanager/resource-manager] Do not omit type and name while serializing the resource object.

### DIFF
--- a/lib/services/trafficManagerManagement2/lib/models/endpoint.js
+++ b/lib/services/trafficManagerManagement2/lib/models/endpoint.js
@@ -81,7 +81,6 @@ class Endpoint extends models['ProxyResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -89,7 +88,6 @@ class Endpoint extends models['ProxyResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/heatMapModel.js
+++ b/lib/services/trafficManagerManagement2/lib/models/heatMapModel.js
@@ -56,7 +56,6 @@ class HeatMapModel extends models['ProxyResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -64,7 +63,6 @@ class HeatMapModel extends models['ProxyResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/index.d.ts
+++ b/lib/services/trafficManagerManagement2/lib/models/index.d.ts
@@ -130,8 +130,8 @@ export interface TrafficFlow {
  */
 export interface Resource extends BaseResource {
   id?: string;
-  readonly name?: string;
-  readonly type?: string;
+  name?: string;
+  type?: string;
 }
 
 /**

--- a/lib/services/trafficManagerManagement2/lib/models/profile.js
+++ b/lib/services/trafficManagerManagement2/lib/models/profile.js
@@ -98,7 +98,6 @@ class Profile extends models['TrackedResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -106,7 +105,6 @@ class Profile extends models['TrackedResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/proxyResource.js
+++ b/lib/services/trafficManagerManagement2/lib/models/proxyResource.js
@@ -49,7 +49,6 @@ class ProxyResource extends models['Resource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -57,7 +56,6 @@ class ProxyResource extends models['Resource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/resource.js
+++ b/lib/services/trafficManagerManagement2/lib/models/resource.js
@@ -53,7 +53,6 @@ class Resource extends models['BaseResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -61,7 +60,6 @@ class Resource extends models['BaseResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/trackedResource.js
+++ b/lib/services/trafficManagerManagement2/lib/models/trackedResource.js
@@ -50,7 +50,6 @@ class TrackedResource extends models['Resource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -58,7 +57,6 @@ class TrackedResource extends models['Resource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/trafficManagerGeographicHierarchy.js
+++ b/lib/services/trafficManagerManagement2/lib/models/trafficManagerGeographicHierarchy.js
@@ -55,7 +55,6 @@ class TrafficManagerGeographicHierarchy extends models['ProxyResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -63,7 +62,6 @@ class TrafficManagerGeographicHierarchy extends models['ProxyResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'

--- a/lib/services/trafficManagerManagement2/lib/models/userMetricsModel.js
+++ b/lib/services/trafficManagerManagement2/lib/models/userMetricsModel.js
@@ -49,7 +49,6 @@ class UserMetricsModel extends models['ProxyResource'] {
           },
           name: {
             required: false,
-            readOnly: true,
             serializedName: 'name',
             type: {
               name: 'String'
@@ -57,7 +56,6 @@ class UserMetricsModel extends models['ProxyResource'] {
           },
           type: {
             required: false,
-            readOnly: true,
             serializedName: 'type',
             type: {
               name: 'String'


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4007