### PR TITLE
Define msiEndpoint and msiSecret as optional

### DIFF
--- a/runtime/ms-rest-azure/index.d.ts
+++ b/runtime/ms-rest-azure/index.d.ts
@@ -691,13 +691,13 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
    * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
    * For example: `MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
    */
-  msiEndpoint: string;
+  msiEndpoint?: string;
   /**
    * @property {string} msiSecret - The secret used in communication between your code and the local MSI agent.
    * Either provide this parameter or set the environment varaible `MSI_SECRET`.
    * For example: `MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
    */
-  msiSecret: string;
+  msiSecret?: string;
   /**
    * @property {string} [msiApiVersion] The api-version of the local MSI agent. Default value is "2017-09-01".
    */


### PR DESCRIPTION
These parameters are optional because their values are set from environment variables provided by App Service.