### PR TITLE
Made msiEndpoint and msiSecret optional

### DIFF
--- a/runtime/ms-rest-azure/index.d.ts
+++ b/runtime/ms-rest-azure/index.d.ts
@@ -940,13 +940,13 @@ export interface MSIAppServiceOptions extends MSIOptions {
    * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
    * For example: `export MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
    */
-  msiEndpoint: string;
+  msiEndpoint?: string;
   /**
    * @property {string} [msiSecret] - The secret used in communication between your code and the local MSI agent.
    * Either provide this parameter or set the environment varaible `MSI_SECRET`.
    * For example: `export MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
    */
-  msiSecret: string;
+  msiSecret?: string;
   /**
    * @property {string} [msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
    */


### PR DESCRIPTION
The options msiEndpoint and msiSecret should be optional as their are loaded from environment by default and does not have to be present to provide another options (e.g. resource). See [line 35-36](https://github.com/Azure/azure-sdk-for-node/blob/27d21ee19fde8bbec45d0b53bcaaf56e8d1beeb3/runtime/ms-rest-azure/lib/credentials/msiAppServiceTokenCredentials.js#L35).

Currently I have to use it as `await msRestAzure.loginWithAppServiceMSI({ resource: "https://vault.azure.net" } as msRestAzure.MSIAppServiceTokenCredentials);`

