### PR TITLE
Update createOrUpdateInstallation documentation

### DIFF
--- a/lib/services/serviceBus/lib/notificationhubservice.js
+++ b/lib/services/serviceBus/lib/notificationhubservice.js
@@ -456,13 +456,48 @@ NotificationHubService.prototype._sendNotification = function (payload, optionsO
 };
 
 /**
+ *  @typedef TemplateDescription
+ *  @type {object}
+ *  @property {string} body                         Template for the body of notification payload.
+ *                                                  Body must be JSON for APNS,GCM & ADM
+ *                                                  Body must be XML for WNS and MPNS (except when raw)
+ *  @property {Object.<string,string>} [headers]    JSON object where each property is a header name and value is a template expression.
+ *                                                  Templates for WNS must include X-WNS-Type header.              
+ *  @property {string} [expiry]                     Template expression evaluating in W3D date format.
+ *  @property {string[]} [tags] Array of tags for this template.
+ */
+
+/**
+ * @typedef {Object<string, TemplateDescription} TemplateDictionary
+ * /
+
+/**
+ *  @typedef SecondaryTile
+ *  @type {object}
+ *  @property {string} pushChannel ChannelUri for secondary tile.
+ *  @property {string[]} [tags] Tags for native notifications to secondary tile.
+ *  @property {TemplateDictionary} [templates] Ordinary template but for each secondary tile.
+ */
+
+ /**
+  * @typedef {Object<string, SecondaryTile} TilesDictionary
+  */
+
+/**
 * Creates or updates a installation.
 *
-* @param {string}             installation              The installation to create/update.
-* @param {object}             [options]                 The request options or callback function. Additional properties will be passed as headers.
-* @param {Function(error, response)} callback           `error` will contain information
-*                                                       if an error occurs; otherwise, `response`
-*                                                       will contain information related to this operation.
+* @param {object}             installation                      The installation to create/update.
+* @param {string}             installation.installationId       GUID of the installation
+* @param {string}             installation.platform             Can be {apns, wns, mpns, adm, gcm}.
+* @param {string}             installation.pushChannel          The PNS handle for this installation, 
+*                                                               (in case of WNS the ChannelUri of the ApplicationTile)
+* @param {string[]}           [installation.tags]               An array of tags. Tags are strings as defined in hub specs.
+* @param {TemplateDictionary} [templates]                       A JSON object representing a dictionary of templateNames to template description.
+* @param {TilesDictionary}    [secondaryTiles]         
+* @param {object}             [options]                         The request options or callback function. Additional properties will be passed as headers.
+* @param {Function(error, response)} callback                   `error` will contain information
+*                                                               if an error occurs; otherwise, `response`
+*                                                               will contain information related to this operation.
 */
 NotificationHubService.prototype.createOrUpdateInstallation = function (installation, optionsOrCallback, callback) {
   var options;


### PR DESCRIPTION
Existing documentation describes the installation parameter as a string. It is actually an installation object.

The correct parameter can be in seen in the [Notification Hub REST API Documentation ](https://docs.microsoft.com/en-us/previous-versions/azure/reference/mt621153(v%3dazure.100)#request-body)

You can see evidence that it's an object [here ](https://github.com/Azure/azure-sdk-for-node/blob/1f7ddb946a5537c43a576d3842867d12b78d80cf/lib/services/serviceBus/lib/notificationhubservice.js#L512) or in the screenshot below:
![image](https://user-images.githubusercontent.com/6028185/51177988-2f07c200-1926-11e9-9719-b222054a3f42.png)

I have tested this in my own application and have confirmed that the parameter described in the REST API Documentation is the correct one.


I have also created a [pull request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32166) to update the type used in the @types/azure-sb package




