### PR TITLE
Remove hard coded string “servicebus.windows.net” and use host name

### DIFF
--- a/lib/services/serviceBus/lib/servicebusservice.js
+++ b/lib/services/serviceBus/lib/servicebusservice.js
@@ -302,8 +302,8 @@ ServiceBusService.prototype.deleteMessage = function (message, callback) {
   }
 
   var relativePath = message.location.substr(
-    message.location.indexOf(ServiceClientConstants.CLOUD_SERVICEBUS_HOST + '/') +
-    ServiceClientConstants.CLOUD_SERVICEBUS_HOST.length + 1);
+    message.location.indexOf(this.host + '/') +
+    this.host.length + 1);
 
   var webResource = WebResource.del(relativePath)
     .withRawResponse();
@@ -335,8 +335,8 @@ ServiceBusService.prototype.unlockMessage = function (message, callback) {
   }
 
   var relativePath = message.location.substr(
-    message.location.indexOf(ServiceClientConstants.CLOUD_SERVICEBUS_HOST + '/') +
-    ServiceClientConstants.CLOUD_SERVICEBUS_HOST.length + 1);
+    message.location.indexOf(this.host + '/') +
+    this.host.length + 1);
 
   var webResource = WebResource.put(relativePath)
     .withRawResponse();
@@ -368,8 +368,8 @@ ServiceBusService.prototype.renewLockForMessage = function (message, callback) {
   }
 
   var relativePath = message.location.substr(
-    message.location.indexOf(ServiceClientConstants.CLOUD_SERVICEBUS_HOST + '/') +
-    ServiceClientConstants.CLOUD_SERVICEBUS_HOST.length + 1);
+    message.location.indexOf(this.host + '/') +
+    this.host.length + 1);
 
   var webResource = WebResource.post(relativePath)
     .withRawResponse();

--- a/lib/services/serviceBus/lib/servicebusservicebase.js
+++ b/lib/services/serviceBus/lib/servicebusservicebase.js
@@ -80,7 +80,7 @@ function ServiceBusServiceBase(configOrNamespaceOrConnectionStringOrSettings, ac
       }
     }
 
-    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + ServiceClientConstants.CLOUD_ACCESS_CONTROL_HOST });
+    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + ServiceClientConstants.CLOUD_SERVICEBUS_HOST });
     var stsendpoint = url.format({ protocol: 'https:', port: 443, hostname: acsNamespace + '.' + ServiceClientConstants.CLOUD_ACCESS_CONTROL_HOST });
 
     if (host) {

--- a/lib/services/serviceBus/lib/servicebusservicebase.js
+++ b/lib/services/serviceBus/lib/servicebusservicebase.js
@@ -80,8 +80,8 @@ function ServiceBusServiceBase(configOrNamespaceOrConnectionStringOrSettings, ac
       }
     }
 
-    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + this.host });
-    var stsendpoint = url.format({ protocol: 'https:', port: 443, hostname: acsNamespace + '.' + this.host });
+    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + ServiceClientConstants.CLOUD_ACCESS_CONTROL_HOST });
+    var stsendpoint = url.format({ protocol: 'https:', port: 443, hostname: acsNamespace + '.' + ServiceClientConstants.CLOUD_ACCESS_CONTROL_HOST });
 
     if (host) {
       endpoint = url.format(ServiceSettings.parseHost(host));

--- a/lib/services/serviceBus/lib/servicebusservicebase.js
+++ b/lib/services/serviceBus/lib/servicebusservicebase.js
@@ -80,8 +80,8 @@ function ServiceBusServiceBase(configOrNamespaceOrConnectionStringOrSettings, ac
       }
     }
 
-    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + ServiceClientConstants.CLOUD_SERVICEBUS_HOST });
-    var stsendpoint = url.format({ protocol: 'https:', port: 443, hostname: acsNamespace + '.' + ServiceClientConstants.CLOUD_ACCESS_CONTROL_HOST });
+    var endpoint = url.format({ protocol: 'https:', port: 443, hostname: configOrNamespaceOrConnectionStringOrSettings + '.' + this.host });
+    var stsendpoint = url.format({ protocol: 'https:', port: 443, hostname: acsNamespace + '.' + this.host });
 
     if (host) {
       endpoint = url.format(ServiceSettings.parseHost(host));


### PR DESCRIPTION
This pr removes hard coded string “servicebus.windows.net” and add host name.

Some methods(delete, unlock etc) fails for china users because the string “servicebus.windows.net” is hardcoded and used in substring operations, so it forms bad url for china users.
