### PR TITLE
Fix vscode config file

### DIFF
--- a/runtime/ms-rest/.vscode/launch.json
+++ b/runtime/ms-rest/.vscode/launch.json
@@ -1,17 +1,18 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Mocha (Test single file)",
-        "type": "node",
-        "request": "launch",
-        "runtimeArgs": [
-          "${workspaceRoot}/node_modules/.bin/mocha",
-          "--inspect-brk",
-          "${relativeFile}",
-        ],
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "port": 9229
-      }
-  }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Mocha (Test single file)",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "${workspaceRoot}/node_modules/.bin/mocha",
+        "--inspect-brk",
+        "${relativeFile}",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}


### PR DESCRIPTION
The file was missing an `]`, this was causing some headaches
when we use this package as a dependency.