### PR TITLE
Adding keyvault tests in the end

### DIFF
--- a/test/testlistarm.txt
+++ b/test/testlistarm.txt
@@ -39,11 +39,11 @@ services/notificationHubsManagement/namespace-tests.js
 services/notificationHubsManagement/notificationHub-tests.js
 services/devTestLabs/devTestLabsClient-tests.js
 services/iothub/iothubClient-tests.js
+services/postgresqlManagement/postgreSQLManagementClient-tests.js
+services/mysqlManagement/mySQLManagementClient-tests.js
+services/loganalytics/loganalytics-query-tests.js
 services/keyVault/keyVault-key-tests.js
 services/keyVault/keyVault-secret-tests.js
 services/keyVault/keyVault-certificate-tests.js
 services/keyVault/keyVault-storage-tests.js
 services/keyVaultManagement/keyVaultManagement-tests.js
-services/postgresqlManagement/postgreSQLManagementClient-tests.js
-services/mysqlManagement/mySQLManagementClient-tests.js
-services/loganalytics/loganalytics-query-tests.js


### PR DESCRIPTION
Looks like the keyvault tests are running in live mode instead of playback in CI and hence causing failures.