### PR TITLE
Fix proxy with credentials

### DIFF
--- a/lib/common/lib/services/serviceclient.js
+++ b/lib/common/lib/services/serviceclient.js
@@ -864,7 +864,7 @@ ServiceClient.prototype._setDefaultProxy = function () {
       parsedUrl.port = 80;
     }
     if (parsedUrl.auth) {
-      parsedUrl.proxyAuth = parsedUrl.auth
+      parsedUrl.proxyAuth = parsedUrl.auth;
     }
     this.setProxy(parsedUrl);
   } else {

--- a/lib/common/lib/services/serviceclient.js
+++ b/lib/common/lib/services/serviceclient.js
@@ -863,6 +863,9 @@ ServiceClient.prototype._setDefaultProxy = function () {
     if (!parsedUrl.port) {
       parsedUrl.port = 80;
     }
+    if (parsedUrl.auth) {
+      parsedUrl.proxyAuth = parsedUrl.auth
+    }
     this.setProxy(parsedUrl);
   } else {
     this.setProxy(null);


### PR DESCRIPTION
tunnel proxy use proxyauth attribute and not auth (that is given by url.prase)
without this fix, setting a proxy to any azure http service (like service bus) with username and password will fail