### PR TITLE
use right class name for import

### DIFF
--- a/lib/services/billingManagement/README.md
+++ b/lib/services/billingManagement/README.md
@@ -19,7 +19,7 @@ npm install azure-arm-billing
 
  ```javascript
  const msRestAzure = require('ms-rest-azure');
- const BillingManagement = require("azure-arm-billing");
+ const BillingManagementClient = require("azure-arm-billing");
  
  // Interactive Login
  // It provides a url and code that needs to be copied and pasted in a browser and authenticated over there. If successful, 


### PR DESCRIPTION
On line 28 we initiate a client by calling `BillingManagementClient`. However, we import BillingManagement. Update this to be consistent with the call we make.