### PR TITLE
ms-rest need to support dash to the parameter name in path template

### DIFF
--- a/runtime/ms-rest/Changelog.md
+++ b/runtime/ms-rest/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
+
+## 2.5.4
+
+- Added support for parameter names which contain dash(-) in path template in webResource.
+
 ## 2.5.3
+
 - Do not serialize default values for model properties.
 - During deserialization, set the value of an entity to it's default value if specified in the mapper.
 

--- a/runtime/ms-rest/lib/webResource.js
+++ b/runtime/ms-rest/lib/webResource.js
@@ -169,7 +169,7 @@ class WebResource {
       }
       let baseUrl = options.baseUrl;
       let url = baseUrl + (baseUrl.endsWith('/') ? '' : '/') + (options.pathTemplate.startsWith('/') ? options.pathTemplate.slice(1) : options.pathTemplate);
-      let segments = url.match(/({\w*\s*\w*})/ig);
+      let segments = url.match(/({[\w\-]*\s*[\w\-]*})/ig);
       if (segments && segments.length) {
         if (options.pathParameters === null || options.pathParameters === undefined || typeof options.pathParameters !== 'object') {
           throw new Error(`pathTemplate: ${options.pathTemplate} has been provided. Hence, options.pathParameters ` +

--- a/runtime/ms-rest/package.json
+++ b/runtime/ms-rest/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-node"
   },
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Client Runtime for Node.js client libraries generated using AutoRest",
   "tags": [
     "node",

--- a/runtime/ms-rest/test/testlist.txt
+++ b/runtime/ms-rest/test/testlist.txt
@@ -7,3 +7,4 @@ logFilterTests.js
 redirectFilterTests.js
 userAgentFilterTests.js
 rpRegistrationFilterTests.js
+webResourceTests.js

--- a/runtime/ms-rest/test/webResourceTests.js
+++ b/runtime/ms-rest/test/webResourceTests.js
@@ -2,8 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 var assert = require('assert');
-var webResource =require('../lib/webResource')
-
+var webResource = require('../lib/webResource')
 
 describe('web resoure', function () {
 

--- a/runtime/ms-rest/test/webResourceTests.js
+++ b/runtime/ms-rest/test/webResourceTests.js
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+var assert = require('assert');
+var webResource =require('../lib/webResource')
+
+
+describe('web resoure', function () {
+
+  it('should support dash in parameter name', function (done) {
+     var options = {
+       headers:{
+        "Content-Type": "application/x-www-form-urlencoded"
+       },
+       method:"get",
+       url:"",
+       pathTemplate:"/pet/{pet-name}/{one-friend-name}",
+       pathParameters: {
+         "pet-name":"tom",
+         "one-friend-name":"jerry"
+       }
+     }
+     var request = new webResource()
+     request = request.prepare(options)
+     assert.equal(request.url,"https://management.azure.com/pet/tom/jerry")
+     done()
+  });
+});
+


### PR DESCRIPTION
Currently, there are specs included parameter name with dash (-) , but ms-rest could not process correctly   the url with segments that contains dash , that  will caused the oav  failed  when swagger reviewing  , because the oav use ms-rest to generate a http-request from an example json file
an example specs:
[KeyVault](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json#L82)
