### PR TITLE
[azure-keyvault] Incorrect authentication in README

### DIFF
--- a/lib/services/keyVault/README.md
+++ b/lib/services/keyVault/README.md
@@ -34,7 +34,7 @@ For a complete sample, please check one of the above links.
 
 ```javascript
 var KeyVault = require('azure-keyvault');
-var msRestAzure = require('ms-rest-azure');
+var msRestAzure = require('ms-rest-nodeauth');
 
 async function main(): Promise<void> {
   const credentials = await msRestAzure.interactiveLogin();


### PR DESCRIPTION
`azure-keyvault` currently doesn't work with `ms-rest-azure`. It does work with `ms-rest-nodeauth` though.

Here's the code that I'm using to confirm that `ms-rest-azure` isn't working:

```ts
import * as KeyVault from "azure-keyvault";
import * as msRestAzure from "ms-rest-azure";
import { config } from "dotenv";

config();

async function main(): Promise<void> {
  const credentials = await msRestAzure.loginWithServicePrincipalSecret(
    process.env.AZURE_CLIENT_ID,
    process.env.AZURE_CLIENT_SECRET,
    process.env.AZURE_TENANT_ID
  );
  const client = new KeyVault.KeyVaultClient(credentials);
  const keyVaultUrl = `https://${process.env.KEYVAULT_NAME}.vault.azure.net`;
  await client.getKeys(keyVaultUrl);
}

main();
```

Fixes https://github.com/Azure/azure-sdk-for-node/issues/5153