### PR TITLE
[azure-keyvault] Mentioning the ms-rest-azure requirements

### DIFF
--- a/lib/services/keyVault/README.md
+++ b/lib/services/keyVault/README.md
@@ -1,8 +1,14 @@
 # Microsoft Azure SDK for Node.js - Key Vault
 
-This project provides a Node.js package for accessing keys, secrets and certificates on Azure Key Vault. Right now it supports:
+This project provides a Node.js package for accessing keys, secrets and certificates on Azure Key Vault.
+
+Right now it supports:
 - **Node.js version: 6.x.x or higher**
 - **REST API version: 7.0**
+- **ms-rest-azure version 2.6.0**.  
+  We recommend authenticating with `KeyvaultCredentials`, either the one exported by this package (`azure-keyvault`),
+  or the one that comes with `ms-rest-azure` version 2.6.0,
+  though other authentication methods from `ms-rest-azure` version 2.6.0 are supported.
 
 ## Features
 

--- a/lib/services/keyVault/README.md
+++ b/lib/services/keyVault/README.md
@@ -2,10 +2,11 @@
 
 This project provides a Node.js package for accessing keys, secrets and certificates on Azure Key Vault.
 
-Right now it supports:
+It supports:
 - **Node.js version: 6.x.x or higher**
-- **REST API version: 7.0**
-- **ms-rest-azure version 2.6.0**
+- **Keyvault REST API version: 7.0**
+
+> Note: Only version 2.6.0 of `ms-rest-azure` package can be used to authenticate. Higher versions of this package are not supported.
 
 ## Features
 

--- a/lib/services/keyVault/README.md
+++ b/lib/services/keyVault/README.md
@@ -5,10 +5,7 @@ This project provides a Node.js package for accessing keys, secrets and certific
 Right now it supports:
 - **Node.js version: 6.x.x or higher**
 - **REST API version: 7.0**
-- **ms-rest-azure version 2.6.0**.  
-  We recommend authenticating with `KeyvaultCredentials`, either the one exported by this package (`azure-keyvault`),
-  or the one that comes with `ms-rest-azure` version 2.6.0,
-  though other authentication methods from `ms-rest-azure` version 2.6.0 are supported.
+- **ms-rest-azure version 2.6.0**
 
 ## Features
 


### PR DESCRIPTION
It took me a while to figure out what was going on here: https://github.com/Azure/azure-sdk-for-node/issues/5153

From what was concluded in that issue, this PR shows that `azure-keyvault` only supports `ms-rest-azure` version 2.6.0, and it recommends authenticating with `KeyvaultCredentials`, either the one exported by this package (`azure-keyvault`), or the one that comes with `ms-rest-azure` version 2.6.0, while also stating that other authentication methods from `ms-rest-azure` version 2.6.0 are supported.