### PR TITLE
update-legacystorage-test-against-the-latest-code

### DIFF
--- a/test/services/blob/blobservice-gb-tests.js
+++ b/test/services/blob/blobservice-gb-tests.js
@@ -22,7 +22,7 @@ var blobtestutil = require('../../framework/blob-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var containerNames = [];
 var containerNamesPrefix = 'cont';

--- a/test/services/blob/blobservice-longrunning-tests.js
+++ b/test/services/blob/blobservice-longrunning-tests.js
@@ -25,7 +25,7 @@ var testutil = require('../../util/util');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var SharedAccessSignature = storage.SharedAccessSignature;
 var BlobService = storage.BlobService;

--- a/test/services/blob/blobservice-stream-tests.js
+++ b/test/services/blob/blobservice-stream-tests.js
@@ -30,7 +30,7 @@ var blobtestutil = require('../../framework/blob-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var WebResource = common.WebResource;
 var SharedAccessSignature = storage.SharedAccessSignature;

--- a/test/services/blob/blobservice-uploaddownload-scale-test.js
+++ b/test/services/blob/blobservice-uploaddownload-scale-test.js
@@ -18,7 +18,7 @@ var assert = require('assert');
 var fs = require('fs');
 var crypto = require('crypto');
 var util = require('util');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var testPrefix = 'blobservice-uploaddownload-scale_test';
 
 var blobService = null;

--- a/test/services/blob/blobservice-uploaddownload-tests.js
+++ b/test/services/blob/blobservice-uploaddownload-tests.js
@@ -24,7 +24,7 @@ var testutil = require('../../util/util');
 var blobtestutil = require('../../framework/blob-test-utils');
 
 // Lib includes
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var containerNamePrefix = 'upload-download-test';
 var blockIdPrefix = 'block';
 var containerCount = 0;

--- a/test/services/blob/filters-tests.js
+++ b/test/services/blob/filters-tests.js
@@ -21,7 +21,7 @@ var testutil = require('../../util/util');
 var blobtestutil = require('../../framework/blob-test-utils');
 
 // Lib includes
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var testPrefix = 'filter-tests';
 
 var blobService;

--- a/test/services/blob/internal/sharedaccesssignature-tests.js
+++ b/test/services/blob/internal/sharedaccesssignature-tests.js
@@ -23,7 +23,7 @@ var testutil = require('../../../util/util');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var WebResource = common.WebResource;
 var SharedAccessSignature = storage.SharedAccessSignature;
 var Constants = common.Constants;

--- a/test/services/blob/internal/sharedkey-tests.js
+++ b/test/services/blob/internal/sharedkey-tests.js
@@ -21,7 +21,7 @@ var testutil = require('../../../util/util');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var WebResource = common.WebResource;
 var SharedKey = storage.SharedKey;
 var ServiceClientConstants = common.ServiceClientConstants;

--- a/test/services/blob/internal/sharedkeylite-tests.js
+++ b/test/services/blob/internal/sharedkeylite-tests.js
@@ -22,7 +22,7 @@ var blobtestutil = require('../../../framework/blob-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var Constants = common.Constants;
 var HttpConstants = Constants.HttpConstants;

--- a/test/services/queue/listqueuesresultcontinuation-tests.js
+++ b/test/services/queue/listqueuesresultcontinuation-tests.js
@@ -20,7 +20,7 @@ var assert = require('assert');
 var testutil = require('../../util/util');
 
 // Lib includes
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var common = require('azure-common');
 var azureutil = common.util;
 

--- a/test/services/queue/queueservice-tests.js
+++ b/test/services/queue/queueservice-tests.js
@@ -23,7 +23,7 @@ var queuetestutil = require('../../framework/queue-test-utils');
 // Lib includes
 var azure = testutil.libRequire('azure');
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var azureutil = common.util;
 
 var Constants = common.Constants;

--- a/test/services/table/batchserviceclient-tests.js
+++ b/test/services/table/batchserviceclient-tests.js
@@ -22,7 +22,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var BatchServiceClient = testutil.libRequire('services/legacyStorage/lib/table/batchserviceclient');
 var Constants = common.Constants;
 var HttpConstants = Constants.HttpConstants;

--- a/test/services/table/internal/sharedkeylitetable-tests.js
+++ b/test/services/table/internal/sharedkeylitetable-tests.js
@@ -21,7 +21,7 @@ var testutil = require('../../../util/util');
 
 // Lib includes
 var common = require('azure-common');
-var SharedKeyLiteTable = require('azure-storage-legacy').SharedKeyLiteTable;
+var SharedKeyLiteTable = testutil.libRequire('services/legacyStorage').SharedKeyLiteTable;
 var WebResource = common.WebResource;
 var ServiceClientConstants = common.ServiceClientConstants;
 var Constants = common.Constants;

--- a/test/services/table/internal/sharedkeytable-tests.js
+++ b/test/services/table/internal/sharedkeytable-tests.js
@@ -22,7 +22,7 @@ var tabletestutil = require('../../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var SharedKeyLiteTable = storage.SharedKeyLiteTable;
 
 var Constants = common.Constants;

--- a/test/services/table/queryentitiesresultcontinuation-tests.js
+++ b/test/services/table/queryentitiesresultcontinuation-tests.js
@@ -22,9 +22,9 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
-var azureutil = common.util.;
+var azureutil = common.util;
 var testutil = testutil.libRequire('util/util');
 var QueryEntitiesResultContinuation = testutil.libRequire('services/table/models/queryentitiesresultcontinuation');
 

--- a/test/services/table/querytablesresultcontinuation-tests.js
+++ b/test/services/table/querytablesresultcontinuation-tests.js
@@ -22,7 +22,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 var azureutil = common.util;
 var testutil = testutil.libRequire('common/lib/util/util');
 

--- a/test/services/table/tabledatatype-tests.js
+++ b/test/services/table/tabledatatype-tests.js
@@ -23,7 +23,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var azureutil = common.util;
 

--- a/test/services/table/tablequery-tests.js
+++ b/test/services/table/tablequery-tests.js
@@ -22,7 +22,7 @@ var testutil = require('../../util/util');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');;
 
 var TableQuery = storage.TableQuery;
 var azureutil = common.util;

--- a/test/services/table/tableservice-batch-tests.js
+++ b/test/services/table/tableservice-batch-tests.js
@@ -22,7 +22,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var azureutil = common.util;
 

--- a/test/services/table/tableservice-gb-tests.js
+++ b/test/services/table/tableservice-gb-tests.js
@@ -23,7 +23,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var tableNames = [];
 var tablePrefix = 'tableservice';

--- a/test/services/table/tableservice-tablequery-tests.js
+++ b/test/services/table/tableservice-tablequery-tests.js
@@ -22,7 +22,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 
 // Lib includes
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var azureutil = common.util;
 

--- a/test/services/table/tableservice-tests.js
+++ b/test/services/table/tableservice-tests.js
@@ -26,7 +26,7 @@ var tabletestutil = require('../../framework/table-test-utils');
 var common = testutil.libRequire('azure');
 
 var common = require('azure-common');
-var storage = require('azure-storage-legacy');
+var storage = testutil.libRequire('services/legacyStorage');
 
 var azureutil = common.util;
 


### PR DESCRIPTION
update the legacy storage test so that they are testing against the latest code instead of publish version.