### PR TITLE
Updating Azure-SB with Agent-Options and Keep-Alive behavior

### DIFF
--- a/lib/services/serviceBus/README.md
+++ b/lib/services/serviceBus/README.md
@@ -1,7 +1,11 @@
-# Microsoft Azure SDK for Node.js - Gallery
+# Microsoft Azure SDK for Node.js - Service Bus & Notification Hubs
 
-This project provides a Node.js package for accessing the Azure ServiceBus service.
+This project provides a Node.js package `azure-sb` for accessing the below two Azure services:
 
+- Azure Service Bus
+- Azure Notification Hubs
+
+> Please note, a newer package [@azure/service-bus](https://www.npmjs.com/package/@azure/service-bus) for Azure Service Bus is available as of May 2019. The `azure-sb` package will continue to receive critical bug fixes for features around accessing Azure Notification Hubs, but we strongly encourage you to upgrade to the new package for your Service Bus needs.
 
 ## How to Install
 

--- a/lib/services/serviceBus/lib/servicebusserviceclient.js
+++ b/lib/services/serviceBus/lib/servicebusserviceclient.js
@@ -68,6 +68,8 @@ util.inherits(ServiceBusServiceClient, ServiceClient);
  * @param {object} options The agent options which sets the keepAlive and maxSockets properties.
  */
 ServiceBusServiceClient.prototype.setAgentOptions = function (options) {
+  options || (options = {});
+
   this.agentOptions.keepAlive = options.keepAlive == null ? true : options.keepAlive;
   this.agentOptions.maxSockets = options.maxSockets == null ? Infinity : options.maxSockets;
 };

--- a/lib/services/serviceBus/lib/servicebusserviceclient.js
+++ b/lib/services/serviceBus/lib/servicebusserviceclient.js
@@ -68,7 +68,8 @@ util.inherits(ServiceBusServiceClient, ServiceClient);
  * @param {object} options The agent options which sets the keepAlive and maxSockets properties.
  */
 ServiceBusServiceClient.prototype.setAgentOptions = function (options) {
-  this.agentOptions = options;
+  this.agentOptions.keepAlive = options.keepAlive == null ? true : options.keepAlive;
+  this.agentOptions.maxSockets = options.maxSockets == null ? Infinity : options.maxSockets;
 };
 
 /**

--- a/lib/services/serviceBus/lib/servicebusserviceclient.js
+++ b/lib/services/serviceBus/lib/servicebusserviceclient.js
@@ -68,7 +68,9 @@ util.inherits(ServiceBusServiceClient, ServiceClient);
  * @param {object} options The agent options which sets the keepAlive and maxSockets properties.
  */
 ServiceBusServiceClient.prototype.setAgentOptions = function (options) {
-  options || (options = {});
+  if (!options) {
+    options = {};
+  }
 
   this.agentOptions.keepAlive = options.keepAlive == null ? true : options.keepAlive;
   this.agentOptions.maxSockets = options.maxSockets == null ? Infinity : options.maxSockets;

--- a/lib/services/serviceBus/lib/servicebusserviceclient.js
+++ b/lib/services/serviceBus/lib/servicebusserviceclient.js
@@ -16,6 +16,8 @@
 
 // Module dependencies.
 var util = require('util');
+var http = require('http');
+var https = require('https');
 
 var azureCommon = require('azure-common');
 var ServiceClient = azureCommon.ServiceClient;
@@ -50,9 +52,24 @@ function ServiceBusServiceClient(accessKey, issuer, sharedAccessKeyName, sharedA
   }
 
   this.apiVersion = Constants.ServiceBusConstants.CURRENT_API_VERSION;
+
+  // For HTTP Keep Alive
+  this.agentOptions = {
+    keepAlive: true,
+    maxSockets: Infinity
+  };
 }
 
 util.inherits(ServiceBusServiceClient, ServiceClient);
+
+/**
+ * Sets the agent options to be sent to the request method which includes the keepAlive and maxSockets.
+ * 
+ * @param {object} options The agent options which sets the keepAlive and maxSockets properties.
+ */
+ServiceBusServiceClient.prototype.setAgentOptions = function (options) {
+  this.agentOptions = options;
+};
 
 /**
 * Builds the request options to be passed to the http.request method.
@@ -62,6 +79,8 @@ util.inherits(ServiceBusServiceClient, ServiceClient);
 * @param {function(error, requestOptions)}  callback  The callback function.
 */
 ServiceBusServiceClient.prototype._buildRequestOptions = function (webResource, body, options, callback) {
+  var self = this;
+
   webResource.withHeader(HeaderConstants.ACCEPT_CHARSET_HEADER, 'UTF-8');
 
   // Set API version
@@ -79,7 +98,24 @@ ServiceBusServiceClient.prototype._buildRequestOptions = function (webResource, 
     this.authenticationProvider.wrapTokenManager.wrapService.setProxy(this.proxyUrl, this.proxyPort);
   }
 
-  ServiceBusServiceClient['super_'].prototype._buildRequestOptions.call(this, webResource, body, options, callback);
+  var wrappedCallback = function(err, requestOptions) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    requestOptions.agentOptions = self.agentOptions;
+
+    if (self._isHttps()) {
+      requestOptions.agentClass = https.Agent;
+    } else {
+      requestOptions.agentClass = http.Agent;
+    }
+
+    callback(err, requestOptions);
+  };
+
+  ServiceBusServiceClient['super_'].prototype._buildRequestOptions.call(this, webResource, body, options, wrappedCallback);
 };
 
 module.exports = ServiceBusServiceClient;

--- a/lib/services/serviceBus/package.json
+++ b/lib/services/serviceBus/package.json
@@ -9,9 +9,10 @@
     "Janczuk, Tomasz <tjanczuk@microsoft.com>",
     "Rodrigues, Andre <andrerod@microsoft.com>",
     "Tavares, Chris <ctavares@microsoft.com>",
-    "Kulshrestha, Ankur <ankurkul@microsoft.com>"
+    "Kulshrestha, Ankur <ankurkul@microsoft.com>",
+    "Matthew Podwysocki <matthewp@microsoft.com>"
   ],
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Microsoft Azure Service Bus Service Library for node",
   "tags": [
     "azure",
@@ -25,9 +26,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "azure-common": "^0.9.19",
+    "mpns": "2.1.3",
     "underscore": "^1.8.3",
-    "wns": "~0.5.3",
-    "mpns": "2.1.3"
+    "wns": "~0.5.3"
   },
   "homepage": "http://github.com/Azure/azure-sdk-for-node",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "should": "^8.3.1",
     "sinon": "^2.1.0",
     "tslib": "^1.9.3",
-    "typescript": "^3.1.6",
+    "typescript": "^3.5.1",
     "xmlbuilder": "15.1.1",
     "yargs": "3.29.0"
   },

--- a/runtime/ms-rest-azure/package.json
+++ b/runtime/ms-rest-azure/package.json
@@ -41,7 +41,7 @@
     "nock": "^9.3.2",
     "should": "5.2.0",
     "sinon": "^2.3.8",
-    "typescript": "^2.7.2"
+    "typescript": "^3.5.1"
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-node/runtime/ms-rest-azure",
   "repository": {


### PR DESCRIPTION
As per issue #5207 we have an issue with SNAT exhaustion as the behavior of the request library we use does not set the keep alive nor the max number of sockets allowed.  This PR allows the two values of `keepAlive` and `maxSockets` to be set through the `ServiceBusServiceClient.prototype.setAgentOptions` method.

This is then used to override the behavior in `ServiceBusServiceClient.prototype._buildRequestOptions` to override the `callback` parameter to add the two properties to the `requestOptions` to modify the behavior of the request going to the `request` module.